### PR TITLE
Resolves ksni issues in Ubuntu & adding additional menu for battery 

### DIFF
--- a/src/battery_tray.rs
+++ b/src/battery_tray.rs
@@ -66,10 +66,18 @@ impl BatteryTray {
 
 impl Tray for BatteryTray {
     fn icon_name(&self) -> String {
-        "headset".into()
+        "audio-headset".into()
+    }
+    fn id(&self) -> String {
+        env!("CARGO_PKG_NAME").into()
     }
     fn menu(&self) -> Vec<MenuItem<Self>> {
         vec![
+            StandardItem {
+                label: format!("Battery level: {bat}% ({crg})", bat = self.battery_level,crg = (if self.charging.is_some() { "Charging" } else {"Discharging"})).into(),
+                ..Default::default()
+            }
+            .into(),
             StandardItem {
                 label: "Exit".into(),
                 icon_name: "application-exit".into(),
@@ -111,7 +119,7 @@ impl Tray for BatteryTray {
         ToolTip {
             title: "HyperX Cloud II".to_string(),
             description: description,
-            icon_name: "".into(),
+            icon_name: "audio-headset".into(),
             icon_pixmap: Vec::new(),
         }
     }


### PR DESCRIPTION
In Ubuntu the tooltip does not show.

- Replaced the icons to default "audio-headset"
- added a new StandardMenu to show battery % and charging status
- added ID for the ksni Tray