### PR TITLE
Add additional product ID (0x0c9d) for Cloud III Wireless

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="0696", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="1718", ATTRS{idVendor}=="0951", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="05b7", ATTRS{idVendor}=="03f0", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="0c9d", ATTRS{idVendor}=="03f0", MODE="0666"
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="018b", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0696", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="1718", ATTRS{idVendor}=="0951", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="05b7", ATTRS{idVendor}=="03f0", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="0c9d", ATTRS{idVendor}=="03f0", MODE="0666"
 ```
 
 Once created, replug the wireless dongle.

--- a/src/devices/cloud_iii_wireless.rs
+++ b/src/devices/cloud_iii_wireless.rs
@@ -6,7 +6,7 @@ use std::{time::Duration, vec};
 
 const HP: u16 = 0x03F0;
 pub const VENDOR_IDS: [u16; 1] = [HP];
-pub const PRODUCT_IDS: [u16; 1] = [0x05B7];
+pub const PRODUCT_IDS: [u16; 2] = [0x05B7, 0x0c9d]; // Possible Cloud III Wireless product IDs
 
 const BASE_PACKET: [u8; 62] = {
     let mut packet = [0; 62];

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -16,7 +16,7 @@ use thistermination::TerminationFull;
 // Possible vendor IDs [HyperX, HP]
 const VENDOR_IDS: [u16; 2] = [0x0951, 0x03F0];
 // All supported product IDs
-const PRODUCT_IDS: [u16; 6] = [0x1718, 0x018B, 0x0D93, 0x0696, 0x0b92, 0x05B7];
+const PRODUCT_IDS: [u16; 7] = [0x1718, 0x018B, 0x0D93, 0x0696, 0x0b92, 0x05B7, 0x0c9d];
 
 const RESPONSE_BUFFER_SIZE: usize = 256;
 const RESPONSE_DELAY: Duration = Duration::from_millis(50);


### PR DESCRIPTION
Added another product ID for the Cloud III Wireless because my device uses a different product ID than the one in the repo