### PR TITLE
Remove unnecessary clone

### DIFF
--- a/src/status_tray.rs
+++ b/src/status_tray.rs
@@ -58,7 +58,6 @@ impl Tray for StatusTray {
     fn tool_tip(&self) -> ToolTip {
         let description = self
             .message
-            .clone()
             .lines()
             .filter(|l| !l.contains("Unknown"))
             .collect::<Vec<&str>>()


### PR DESCRIPTION
Clone is unnecessary here, it doesn't get moved so we can just remove the clone.

Tested with just `cargo build`, succeeded locally.