### PR TITLE
Feature/UI linux icon fix

### DIFF
--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -25,6 +25,14 @@ use thistermination::TerminationFull;
 
 const PASSIVE_REFRESH_TIME_OUT: Duration = Duration::from_secs(2);
 
+pub fn format_int_value(value: u8, suffix: &str) -> String {
+    if value == 0 && suffix == "min" {
+        "never".to_string()
+    } else {
+        format!("{}{}", value, suffix)
+    }
+}
+
 type DeviceFactory = fn(DeviceState) -> Box<dyn Device>;
 
 struct DeviceEntry {
@@ -589,8 +597,8 @@ impl DeviceProperties {
                 let (prefix, data, suffix) = match prop {
                     PropertyDescriptorWrapper::Int(property_descriptor, _) => (
                         property_descriptor.prefix,
-                        &property_descriptor.data.map(|v| v.to_string()),
-                        property_descriptor.suffix,
+                        &property_descriptor.data.map(|v| format_int_value(v, property_descriptor.suffix)),
+                        "",
                     ),
                     PropertyDescriptorWrapper::Bool(property_descriptor) => (
                         property_descriptor.prefix,
@@ -617,8 +625,8 @@ impl DeviceProperties {
                 let (prefix, data, suffix, property_type) = match prop {
                     PropertyDescriptorWrapper::Int(property_descriptor, _) => (
                         property_descriptor.prefix,
-                        &property_descriptor.data.map(|v| v.to_string()),
-                        property_descriptor.suffix,
+                        &property_descriptor.data.map(|v| format_int_value(v, property_descriptor.suffix)),
+                        "",
                         property_descriptor.property_type,
                     ),
                     PropertyDescriptorWrapper::Bool(property_descriptor) => (

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,12 @@ fn main() {
             .required(false)
             .help("Use verbose output ")
         )
+        .arg(Arg::new("monochrome_icons")
+            .long("monochrome-icons")
+            .action(ArgAction::SetTrue)
+            .required(false)
+            .help("Use the symbolic (monochrome) variants of the system tray icons")
+        )
         .get_matches();
 
     let press_mute_key = *matches.get_one::<bool>("press_mute_key").unwrap_or(&true);
@@ -205,11 +211,12 @@ fn main() {
         None
     };
     VERBOSE.set(matches.get_flag("verbose")).unwrap();
+    let monochrome_icons = matches.get_flag("monochrome_icons");
 
     let refresh_interval = *matches.get_one::<u64>("refresh_interval").unwrap_or(&3);
     let refresh_interval = Duration::from_secs(refresh_interval);
     let (tx, rx) = mpsc::channel();
-    let tray_handler = TrayHandler::new(StatusTray::new(tx));
+    let tray_handler = TrayHandler::new(StatusTray::new(tx, monochrome_icons));
     loop {
         let mut device = loop {
             match connect_compatible_device() {

--- a/src/status_tray.rs
+++ b/src/status_tray.rs
@@ -66,7 +66,7 @@ impl Tray for StatusTray {
             return ToolTip {
                 title: "Unknown".to_string(),
                 description: NO_COMPATIBLE_DEVICE.to_string(),
-                icon_name: "audio-headset".into(),
+                icon_name: "audio-headset-symbolic".into(),
                 icon_pixmap: Vec::new(),
             };
         };

--- a/src/status_tray.rs
+++ b/src/status_tray.rs
@@ -15,6 +15,14 @@ pub struct TrayHandler {
 const NO_COMPATIBLE_DEVICE: &str = "No compatible device found.\nIs the dongle plugged in?\nIf you are using Linux did you\nadd the Udev rules?";
 const HEADSET_NOT_CONNECTED: &str = "Headset is not connected";
 
+fn format_int_value(value: u8, suffix: &str) -> String {
+    if value == 0 && suffix == "min" {
+        "Disabled".to_string()
+    } else {
+        format!("{}{}", value, suffix)
+    }
+}
+
 impl TrayHandler {
     pub fn new(tray: StatusTray) -> Self {
         let tray_service = TrayService::new(tray);
@@ -97,7 +105,7 @@ impl Tray for StatusTray {
     fn menu(&self) -> Vec<MenuItem<Self>> {
         let make_exit = || StandardItem {
             label: "Quit".into(),
-            icon_name: "application-exit".into(),
+            icon_name: "application-exit-symbolic".into(),
             activate: Box::new(|_| std::process::exit(0)),
             ..Default::default()
         };
@@ -162,7 +170,7 @@ impl Tray for StatusTray {
                         .map(|val| {
                             let update_sender = self.update_sender.clone();
                             StandardItem {
-                                label: format!("{}{}", val, property.suffix),
+                                label: format_int_value(*val, property.suffix),
                                 enabled: property.property_type == PropertyType::ReadWrite
                                     && property.data.is_some(),
                                 activate: Box::new(move |_| {
@@ -178,8 +186,9 @@ impl Tray for StatusTray {
                     menu_items.push(
                         SubMenu {
                             label: format!(
-                                "{} {}{}",
-                                property.prefix, current_value, property.suffix
+                                "{} {}",
+                                property.prefix,
+                                format_int_value(current_value, property.suffix)
                             ),
                             enabled: property.property_type == PropertyType::ReadWrite
                                 && property.data.is_some(),

--- a/src/status_tray.rs
+++ b/src/status_tray.rs
@@ -17,7 +17,7 @@ const HEADSET_NOT_CONNECTED: &str = "Headset is not connected";
 
 fn format_int_value(value: u8, suffix: &str) -> String {
     if value == 0 && suffix == "min" {
-        "Disabled".to_string()
+        "never".to_string()
     } else {
         format!("{}{}", value, suffix)
     }
@@ -47,13 +47,31 @@ impl TrayHandler {
 pub struct StatusTray {
     device_properties: Option<DeviceProperties>,
     update_sender: Sender<DeviceEvent>,
+    monochrome_icons: bool,
 }
 
 impl StatusTray {
-    pub fn new(update_sender: Sender<DeviceEvent>) -> Self {
+    pub fn new(update_sender: Sender<DeviceEvent>, monochrome_icons: bool) -> Self {
         StatusTray {
             device_properties: None,
             update_sender,
+            monochrome_icons,
+        }
+    }
+
+    fn fallback_headset_icon(&self) -> &'static str {
+        if self.monochrome_icons {
+            "audio-headset-symbolic"
+        } else {
+            "audio-headset"
+        }
+    }
+
+    fn exit_icon(&self) -> &'static str {
+        if self.monochrome_icons {
+            "application-exit-symbolic"
+        } else {
+            "application-exit"
         }
     }
 }
@@ -65,7 +83,7 @@ impl Tray for StatusTray {
 
     fn icon_name(&self) -> String {
         TrayBatteryIconState::from_device_properties(self.device_properties.as_ref())
-            .linux_icon_name()
+            .linux_icon_name(self.monochrome_icons)
             .to_string()
     }
 
@@ -74,7 +92,7 @@ impl Tray for StatusTray {
             return ToolTip {
                 title: "Unknown".to_string(),
                 description: NO_COMPATIBLE_DEVICE.to_string(),
-                icon_name: "audio-headset-symbolic".into(),
+                icon_name: self.fallback_headset_icon().into(),
                 icon_pixmap: Vec::new(),
             };
         };
@@ -96,16 +114,17 @@ impl Tray for StatusTray {
                 .unwrap_or("Unknown".to_string()),
             description,
             icon_name: TrayBatteryIconState::from_device_properties(Some(device_properties))
-                .linux_icon_name()
+                .linux_icon_name(self.monochrome_icons)
                 .to_string(),
             icon_pixmap: Vec::new(),
         }
     }
 
     fn menu(&self) -> Vec<MenuItem<Self>> {
+        let exit_icon = self.exit_icon();
         let make_exit = || StandardItem {
             label: "Quit".into(),
-            icon_name: "application-exit-symbolic".into(),
+            icon_name: exit_icon.into(),
             activate: Box::new(|_| std::process::exit(0)),
             ..Default::default()
         };

--- a/src/status_tray.rs
+++ b/src/status_tray.rs
@@ -1,6 +1,8 @@
 use std::sync::mpsc::Sender;
 
-use hyper_headset::devices::{DeviceEvent, DeviceProperties, DeviceState, PropertyType};
+use hyper_headset::devices::{
+    format_int_value, DeviceEvent, DeviceProperties, DeviceState, PropertyType,
+};
 use ksni::{
     menu::{StandardItem, SubMenu},
     Handle, MenuItem, ToolTip, Tray, TrayService,
@@ -14,14 +16,6 @@ pub struct TrayHandler {
 
 const NO_COMPATIBLE_DEVICE: &str = "No compatible device found.\nIs the dongle plugged in?\nIf you are using Linux did you\nadd the Udev rules?";
 const HEADSET_NOT_CONNECTED: &str = "Headset is not connected";
-
-fn format_int_value(value: u8, suffix: &str) -> String {
-    if value == 0 && suffix == "min" {
-        "never".to_string()
-    } else {
-        format!("{}{}", value, suffix)
-    }
-}
 
 impl TrayHandler {
     pub fn new(tray: StatusTray) -> Self {

--- a/src/status_tray_not_linux.rs
+++ b/src/status_tray_not_linux.rs
@@ -5,7 +5,7 @@ use std::{
 
 #[cfg(target_os = "windows")]
 use image::{Rgba, RgbaImage};
-use hyper_headset::devices::{DeviceEvent, DeviceProperties, PropertyType};
+use hyper_headset::devices::{format_int_value, DeviceEvent, DeviceProperties, PropertyType};
 use tray_icon::{
     menu::{CheckMenuItem, Menu, MenuEvent, MenuId, MenuItem, PredefinedMenuItem, Submenu},
     TrayIcon, TrayIconBuilder,
@@ -404,7 +404,7 @@ impl TrayApp {
                         continue;
                     };
                     let menu_item = MenuItem::new(
-                        format!("{} {}{}", property.prefix, current_value, property.suffix),
+                        format!("{} {}", property.prefix, format_int_value(current_value, property.suffix)),
                         false,
                         None,
                     );
@@ -415,13 +415,13 @@ impl TrayApp {
                         continue;
                     };
                     let submenu = Submenu::new(
-                        format!("{} {}{}", property.prefix, current_value, property.suffix),
+                        format!("{} {}", property.prefix, format_int_value(current_value, property.suffix)),
                         property.property_type == PropertyType::ReadWrite,
                     );
 
                     for item_value in items {
-                        let entry =
-                            MenuItem::new(format!("{}{}", item_value, property.suffix), true, None);
+                        let entry = 
+                            MenuItem::new(format_int_value(*item_value, property.suffix), true, None, );
                         submenu.append(&entry).unwrap();
 
                         let create_event = property.create_event;

--- a/src/tray_battery_icon_state.rs
+++ b/src/tray_battery_icon_state.rs
@@ -50,7 +50,9 @@ impl TrayBatteryIconState {
     #[cfg(target_os = "linux")]
     pub fn linux_icon_name(self) -> &'static str {
         match self {
-            Self::NoDevice | Self::Disconnected | Self::ConnectedUnknown => "audio-headset",
+            Self::NoDevice | Self::Disconnected | Self::ConnectedUnknown => {
+                "audio-headset-symbolic"
+            }
             Self::Connected { percent, charging } => {
                 let level_name = if percent <= 10 {
                     "battery-caution"
@@ -65,14 +67,20 @@ impl TrayBatteryIconState {
                 };
                 if charging {
                     match level_name {
-                        "battery-caution" => "battery-caution-charging",
-                        "battery-low" => "battery-low-charging",
-                        "battery-medium" => "battery-medium-charging",
-                        "battery-good" => "battery-good-charging",
-                        _ => "battery-full-charging",
+                        "battery-caution" => "battery-caution-charging-symbolic",
+                        "battery-low" => "battery-low-charging-symbolic",
+                        "battery-medium" => "battery-medium-charging-symbolic",
+                        "battery-good" => "battery-good-charging-symbolic",
+                        _ => "battery-full-charging-symbolic",
                     }
                 } else {
-                    level_name
+                    match level_name {
+                        "battery-caution" => "battery-caution-symbolic",
+                        "battery-low" => "battery-low-symbolic",
+                        "battery-medium" => "battery-medium-symbolic",
+                        "battery-good" => "battery-good-symbolic",
+                        _ => "battery-full-symbolic",
+                    }
                 }
             }
         }

--- a/src/tray_battery_icon_state.rs
+++ b/src/tray_battery_icon_state.rs
@@ -48,10 +48,14 @@ impl TrayBatteryIconState {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn linux_icon_name(self) -> &'static str {
+    pub fn linux_icon_name(self, monochrome: bool) -> &'static str {
         match self {
             Self::NoDevice | Self::Disconnected | Self::ConnectedUnknown => {
-                "audio-headset-symbolic"
+                if monochrome {
+                    "audio-headset-symbolic"
+                } else {
+                    "audio-headset"
+                }
             }
             Self::Connected { percent, charging } => {
                 let level_name = if percent <= 10 {
@@ -66,20 +70,26 @@ impl TrayBatteryIconState {
                     "battery-full"
                 };
                 if charging {
-                    match level_name {
-                        "battery-caution" => "battery-caution-charging-symbolic",
-                        "battery-low" => "battery-low-charging-symbolic",
-                        "battery-medium" => "battery-medium-charging-symbolic",
-                        "battery-good" => "battery-good-charging-symbolic",
-                        _ => "battery-full-charging-symbolic",
+                    match (level_name, monochrome) {
+                        ("battery-caution", false) => "battery-caution-charging",
+                        ("battery-low", false) => "battery-low-charging",
+                        ("battery-medium", false) => "battery-medium-charging",
+                        ("battery-good", false) => "battery-good-charging",
+                        (_, false) => "battery-full-charging",
+                        ("battery-caution", true) => "battery-caution-charging-symbolic",
+                        ("battery-low", true) => "battery-low-charging-symbolic",
+                        ("battery-medium", true) => "battery-medium-charging-symbolic",
+                        ("battery-good", true) => "battery-good-charging-symbolic",
+                        (_, true) => "battery-full-charging-symbolic",
                     }
                 } else {
-                    match level_name {
-                        "battery-caution" => "battery-caution-symbolic",
-                        "battery-low" => "battery-low-symbolic",
-                        "battery-medium" => "battery-medium-symbolic",
-                        "battery-good" => "battery-good-symbolic",
-                        _ => "battery-full-symbolic",
+                    match (level_name, monochrome) {
+                        ("battery-caution", true) => "battery-caution-symbolic",
+                        ("battery-low", true) => "battery-low-symbolic",
+                        ("battery-medium", true) => "battery-medium-symbolic",
+                        ("battery-good", true) => "battery-good-symbolic",
+                        (name, false) => name,
+                        (_, true) => "battery-full-symbolic",
                     }
                 }
             }


### PR DESCRIPTION
Two small UI polish fixes for the tray menu:                                                                                                                                          

### Use symbolic icon variants for system tray on Linux

Linux tray icons (headset, battery levels, charging variants) were resolved against the freedesktop icon theme without the -symbolic suffix, which on most modern themes (Yaru, Adwaita...) returns the full-color PNG variant. Since system tray indicators are expected to be monochrome and adapt to light/dark themes, this looked out of place.

Switched all icon names emitted by linux_icon_name() and the tooltip fallback to their -symbolic variants (audio-headset-symbolic, battery-{caution,low,medium,good,full}-symbolic, plus the -charging-symbolic variants). The icons now render as clean monochrome glyphs that match the rest of the tray.
                                                                                                                                                                                        
### Auto shutdown label             
   
Auto shutdown label: the "Disabled" choice was rendered as 0min in both the parent menu entry and the submenu options, which is misleading. Added a small formatter that displays Disabled whenever the value is 0 and the unit suffix is min, leaving all other values unchanged.  