### PR TITLE
Feature/voice prompt side tone support for Cloud III S Wireless

### DIFF
--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -52,6 +52,7 @@ const COLOR_COMMAND_ID: u8 = 0x4D;
 const CHARGE_STATE_COMMAND_ID: u8 = 0x48;
 const GET_MIC_MUTE_COMMAND_ID: u8 = 0x04;
 const GET_SIDE_TONE_COMMAND_ID: u8 = 0x16;
+const SET_SIDE_TONE_COMMAND_ID: u8 = 0x0D;
 const GET_AUTO_POWER_OFF_COMMAND_ID: u8 = 0x4B;
 const GET_VOICE_PROMPT_COMMAND_ID: u8 = 0x14;
 
@@ -210,8 +211,14 @@ impl Device for CloudIIISWireless {
         Some(packet)
     }
 
-    fn set_side_tone_packet(&self, _side_tone_on: bool) -> Option<Vec<u8>> {
-        None
+    fn set_side_tone_packet(&self, side_tone_on: bool) -> Option<Vec<u8>> {
+        // Confirmed via NGenuity USB capture: `0c 02 03 00 00 0d <0|1>`.
+        // byte[3] = 0x00 marks a SET (vs 0x01 for GET).
+        let mut packet = BASE_PACKET.to_vec();
+        packet[3] = 0x00;
+        packet[5] = SET_SIDE_TONE_COMMAND_ID;
+        packet[6] = side_tone_on as u8;
+        Some(packet)
     }
 
     fn get_side_tone_volume_packet(&self) -> Option<Vec<u8>> {

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -55,6 +55,7 @@ const GET_SIDE_TONE_COMMAND_ID: u8 = 0x16;
 const SET_SIDE_TONE_COMMAND_ID: u8 = 0x0D;
 const GET_AUTO_POWER_OFF_COMMAND_ID: u8 = 0x4B;
 const GET_VOICE_PROMPT_COMMAND_ID: u8 = 0x14;
+const SET_VOICE_PROMPT_COMMAND_ID: u8 = 0x0B;
 
 // Button report header (incoming from headset)
 const CONSUMER_CONTROL_HEADER: u8 = 0x0f;
@@ -235,8 +236,13 @@ impl Device for CloudIIISWireless {
         Some(packet)
     }
 
-    fn set_voice_prompt_packet(&self, _enable: bool) -> Option<Vec<u8>> {
-        None
+    fn set_voice_prompt_packet(&self, enable: bool) -> Option<Vec<u8>> {
+        // Confirmed via NGenuity USB capture: `0c 02 03 00 00 0b <0|1>`.
+        let mut packet = BASE_PACKET.to_vec();
+        packet[3] = 0x00;
+        packet[5] = SET_VOICE_PROMPT_COMMAND_ID;
+        packet[6] = enable as u8;
+        Some(packet)
     }
 
     fn get_wireless_connected_status_packet(&self) -> Option<Vec<u8>> {

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -213,8 +213,6 @@ impl Device for CloudIIISWireless {
     }
 
     fn set_side_tone_packet(&self, side_tone_on: bool) -> Option<Vec<u8>> {
-        // Confirmed via NGenuity USB capture: `0c 02 03 00 00 0d <0|1>`.
-        // byte[3] = 0x00 marks a SET (vs 0x01 for GET).
         let mut packet = BASE_PACKET.to_vec();
         packet[3] = 0x00;
         packet[5] = SET_SIDE_TONE_COMMAND_ID;
@@ -237,7 +235,6 @@ impl Device for CloudIIISWireless {
     }
 
     fn set_voice_prompt_packet(&self, enable: bool) -> Option<Vec<u8>> {
-        // Confirmed via NGenuity USB capture: `0c 02 03 00 00 0b <0|1>`.
         let mut packet = BASE_PACKET.to_vec();
         packet[3] = 0x00;
         packet[5] = SET_VOICE_PROMPT_COMMAND_ID;


### PR DESCRIPTION
### Implement set_side_tone_packet for Cloud III S Wireless                                                                                                                               

The Side Tone entry in the tray menu was greyed out for the Cloud III S because set_side_tone_packet() returned None, which causes the generic property layer to mark the property as ReadOnly. Only the GET command (0x16) was known.

Identified the SET command from a NGenuity USB capture :                                                                                

```
  OUT  0c 02 03 00 00 0d 01    → sidetone ON                                                                                                                                            
  IN   0d 02 03 00 05 01       → notification: sidetone = 1                                                                                                                             
```

The SET protocol uses byte[3] = 0x00 (vs 0x01 for GET) and a dedicated command ID 0x0D (distinct from the GET 0x16). The notification path was already handled by parse_notification (ID 5 → SideToneOn), so the menu now toggles correctly and reflects the new state.                                                                                                    

### Implement set_voice_prompt_packet for Cloud III S Wireless                                                                                                                            

Same issue as side tone: the Voice Prompt entry was read-only because the SET command was unknown. Captured a fresh USB trace of NGenuity toggling voice prompt which gave four clean toggle frames:

```
  OUT  0c 02 03 00 00 0b 01    → voice prompt ON            
  OUT  0c 02 03 00 00 0b 00    → voice prompt OFF                                                                                                                                       
```

The SET command ID is 0x0B (distinct from the GET 0x14), with the same byte[3] = 0x00 SET marker and value at byte[6], matching the format already used for sidetone and auto-shutdown. Implemented set_voice_prompt_packet accordingly; the menu entry is now active and toggling works.
