### PR TITLE
Add libusb transport for Cloud III S Wireless

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -136,7 +136,7 @@ jobs:
           sed -i "/sha256sums=/,/^)/c\sha256sums=(\n  '${{ steps.checksums.outputs.zip }}'\n  '${{ steps.checksums.outputs.rules }}'\n  '${{ steps.checksums.outputs.desktop }}'\n)" aur-bin-pkg/PKGBUILD
 
       - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: hyper-headset-bin
           pkgbuild: ./aur-bin-pkg/PKGBUILD

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
             sed -i "s/^pkgrel=.*/pkgrel=1/" aur-pkg/PKGBUILD
 
         - name: Publish to AUR
-          uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+          uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
 
           with:
             pkgname: hyper-headset-git

--- a/99-HyperHeadset.rules
+++ b/99-HyperHeadset.rules
@@ -15,6 +15,7 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="1749", ATTRS{idVendor}=="0951", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="16c4", ATTRS{idVendor}=="0951", MODE="0666"
 
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
@@ -34,3 +35,4 @@ KERNEL=="hidraw*", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666
 KERNEL=="hidraw*", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="1749", ATTRS{idVendor}=="0951", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="16c4", ATTRS{idVendor}=="0951", MODE="0666"

--- a/99-HyperHeadset.rules
+++ b/99-HyperHeadset.rules
@@ -12,6 +12,7 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="1765", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="1743", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
@@ -28,3 +29,4 @@ KERNEL=="hidraw*", ATTRS{idProduct}=="1765", ATTRS{idVendor}=="03f0", MODE="0666
 KERNEL=="hidraw*", ATTRS{idProduct}=="1743", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"

--- a/99-HyperHeadset.rules
+++ b/99-HyperHeadset.rules
@@ -14,6 +14,7 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="1749", ATTRS{idVendor}=="0951", MODE="0666"
 
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
@@ -32,3 +33,4 @@ KERNEL=="hidraw*", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666
 KERNEL=="hidraw*", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="1749", ATTRS{idVendor}=="0951", MODE="0666"

--- a/99-HyperHeadset.rules
+++ b/99-HyperHeadset.rules
@@ -13,6 +13,7 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="1743", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
 
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
@@ -30,3 +31,4 @@ KERNEL=="hidraw*", ATTRS{idProduct}=="1743", ATTRS{idVendor}=="03f0", MODE="0666
 KERNEL=="hidraw*", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,7 @@ dependencies = [
  "hidapi",
  "image",
  "ksni",
+ "rusb",
  "shell-escape",
  "thistermination",
  "tray-icon",
@@ -1582,6 +1583,18 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libusb1-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2561,6 +2574,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusb"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4"
+dependencies = [
+ "libc",
+ "libusb1-sys",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3056,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_headset"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "clap 4.5.58",
  "dialog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +795,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -1333,6 +1346,7 @@ name = "hyper_headset"
 version = "1.7.0"
 dependencies = [
  "clap 4.5.58",
+ "ctrlc",
  "dialog",
  "enigo",
  "hidapi",
@@ -1753,6 +1767,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_headset"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "clap 4.5.58",
  "dialog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_headset"
-version = "1.7.1"
+version = "1.7.3"
 dependencies = [
  "clap 4.5.58",
  "dialog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "A CLI and tray application for monitoring and managing HyperX hea
 clap = { version = "4.5.32", features = ["derive"] }
 enigo = "0.6.1"
 hidapi = { path = "vendor/hidapi" }
+rusb = "0.9"
 thistermination = "1.0.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 dialog = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper_headset"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 authors = ["Lennard Kittner"]
 description = "A CLI and tray application for monitoring and managing HyperX headsets."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "A CLI and tray application for monitoring and managing HyperX hea
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
+ctrlc = { version = "3.5.2", features = ["termination"] }
 enigo = "0.6.1"
 hidapi = { path = "vendor/hidapi" }
 rusb = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper_headset"
-version = "1.7.1"
+version = "1.7.3"
 edition = "2021"
 authors = ["Lennard Kittner"]
 description = "A CLI and tray application for monitoring and managing HyperX headsets."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper_headset"
-version = "1.7.3"
+version = "1.8.0"
 edition = "2021"
 authors = ["Lennard Kittner"]
 description = "A CLI and tray application for monitoring and managing HyperX headsets."

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Options:
           Mute or unmute playback. [possible values: true, false]
       --activate_noise_gate <activate_noise_gate>
           Activates noise gate. [possible values: true, false]
+  -v, --verbose
+          Use verbose output
   -h, --help
           Print help
   -V, --version
@@ -166,6 +168,8 @@ Options:
           Set the refresh interval (in seconds) [default: 3]
       --press_mute_key <press_mute_key>
           The app will simulate pressing the microphone mute key whoever the headsets is muted or unmuted. [default: true] [possible values: true, false]
+  -v, --verbose
+          Use verbose output
   -h, --help
           Print help
   -V, --version

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ MacOS:
 
 `brew install libusb`
 
+GNOME:
+
+You may have to install [AppIndicator and KStatusNotifierItem Support](https://extensions.gnome.org/extension/615/appindicator-support/) and [Status Icons ](https://extensions.gnome.org/extension/7332/status-icons/)
+
 ### Udev (Linux only)
 
 Normally the program installs the required udev rules automatically on first launch.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Both the CLI and tray applications are compatible with Linux, MacOS, and Windows
 - HyperX Cloud III S Wireless
 - HyperX Cloud Stinger 2 Wireless
 - HyperX Cloud Flight S
+- HyperX Cloud Flight Wireless
 - HyperX Cloud Alpha Wireless
 
 If your headset is not supported, feel free to open an issue; be sure to include the name, product ID, and vendor ID.
@@ -37,7 +38,7 @@ No manual setup required (dependencies and udev rules are handled automatically)
 ```bash
 yay -S hyper-headset-git
 ```
-or 
+or
 ```bash
 yay -S hyper-headset-bin
 ```
@@ -106,6 +107,7 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="1743", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="018b", ATTRS{idVendor}=="03f0", MODE="0666"
@@ -122,6 +124,7 @@ KERNEL=="hidraw*", ATTRS{idProduct}=="1743", ATTRS{idVendor}=="03f0", MODE="0666
 KERNEL=="hidraw*", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
 ```
 
 Once created, replug the wireless dongle.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="1749", ATTRS{idVendor}=="0951", MODE="0666"
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="018b", ATTRS{idVendor}=="03f0", MODE="0666"
@@ -125,6 +126,7 @@ KERNEL=="hidraw*", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666
 KERNEL=="hidraw*", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="1749", ATTRS{idVendor}=="0951", MODE="0666"
 ```
 
 Once created, replug the wireless dongle.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="1765", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="1743", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="018b", ATTRS{idVendor}=="03f0", MODE="0666"
@@ -120,6 +121,7 @@ KERNEL=="hidraw*", ATTRS{idProduct}=="1765", ATTRS{idVendor}=="03f0", MODE="0666
 KERNEL=="hidraw*", ATTRS{idProduct}=="1743", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="069f", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 ```
 
 Once created, replug the wireless dongle.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ SUBSYSTEMS=="usb", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idProduct}=="1749", ATTRS{idVendor}=="0951", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idProduct}=="16c4", ATTRS{idVendor}=="0951", MODE="0666"
 
 KERNEL=="hidraw*", ATTRS{idProduct}=="0d93", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="018b", ATTRS{idVendor}=="03f0", MODE="0666"
@@ -127,6 +128,7 @@ KERNEL=="hidraw*", ATTRS{idProduct}=="0995", ATTRS{idVendor}=="03f0", MODE="0666
 KERNEL=="hidraw*", ATTRS{idProduct}=="02cc", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="0e90", ATTRS{idVendor}=="03f0", MODE="0666"
 KERNEL=="hidraw*", ATTRS{idProduct}=="1749", ATTRS{idVendor}=="0951", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idProduct}=="16c4", ATTRS{idVendor}=="0951", MODE="0666"
 ```
 
 Once created, replug the wireless dongle.

--- a/src/bin/hyper_headset_cli.rs
+++ b/src/bin/hyper_headset_cli.rs
@@ -1,11 +1,51 @@
 use std::time::Duration;
 
-use clap::{Arg, Command};
-use hyper_headset::devices::{connect_compatible_device, DeviceEvent};
+use clap::{Arg, ArgAction, Command};
+use hyper_headset::{
+    devices::{connect_compatible_device, Device, DeviceError, DeviceEvent},
+    VERBOSE,
+};
 
 const SHOW_ALL_OPTIONS: bool = false;
 
+/// helper function to enable help messages
+fn device_supports<F>(device: &Result<Box<dyn Device>, DeviceError>, f: F) -> bool
+where
+    F: FnOnce(&Box<dyn Device>) -> bool,
+{
+    device.as_ref().map(f).unwrap_or(false)
+}
+
 fn main() {
+    let pre = Command::new(env!("CARGO_PKG_NAME"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .disable_version_flag(true) // we have to implement version manually
+        .disable_help_flag(true)
+        .arg(
+            Arg::new("verbose")
+                .long("verbose")
+                .short('v')
+                .action(ArgAction::SetTrue)
+                .required(false)
+                .help("Use verbose output "),
+        )
+        .arg(
+            Arg::new("version")
+                .long("version")
+                .short('V')
+                .action(ArgAction::SetTrue),
+        )
+        .allow_external_subcommands(true)
+        .try_get_matches();
+
+    if let Ok(pre) = pre {
+        VERBOSE.set(pre.get_flag("verbose")).unwrap();
+        if pre.get_flag("version") {
+            println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+            return;
+        }
+    }
+
     #[cfg(target_os = "linux")]
     {
         use hyper_headset::act_as_askpass_handler;
@@ -22,16 +62,12 @@ fn main() {
         }
         prompt_user_for_udev_rule();
     }
-    let mut device = match connect_compatible_device() {
-        Ok(device) => device,
-        Err(error) => {
-            eprintln!("{error}");
-            std::process::exit(1);
-        }
-    };
+
+    let device = connect_compatible_device();
 
     let matches = Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
+        .disable_version_flag(false)
         .author(env!("CARGO_PKG_AUTHORS"))
         .about("A CLI application for monitoring and managing HyperX headsets.")
         .after_help("Help only lists commands supported by this headset.")
@@ -43,7 +79,7 @@ fn main() {
                     "Set the delay in minutes after which the headset will automatically shutdown.\n0 will disable automatic shutdown.",
                 )
                     .hide(!SHOW_ALL_OPTIONS
-                    && !device.can_set_automatic_shutdown())
+                        && !device_supports(&device, |d| d.can_set_automatic_shutdown()))
                 .value_parser(clap::value_parser!(u8)),
         )
         .arg(
@@ -52,7 +88,7 @@ fn main() {
                 .required(false)
                 .help("Mute or unmute the headset.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device.can_set_mute())
+                    && !device_supports(&device, |d| d.can_set_mute()))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -61,7 +97,7 @@ fn main() {
                 .required(false)
                 .help("Enable or disable side tone.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device.can_set_side_tone())
+                    && !device_supports(&device, |d| d.can_set_side_tone()))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -70,7 +106,7 @@ fn main() {
                 .required(false)
                 .help("Set the side tone volume.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device.can_set_side_tone_volume())
+                    && !device_supports(&device, |d| d.can_set_side_tone_volume()))
                 .value_parser(clap::value_parser!(u8)),
         )
         .arg(
@@ -79,7 +115,7 @@ fn main() {
                 .required(false)
                 .help("Enable voice prompt. This may not be supported on your device.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device.can_set_voice_prompt())
+                    && !device_supports(&device, |d| d.can_set_voice_prompt()))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -88,7 +124,7 @@ fn main() {
                 .required(false)
                 .help("Enables surround sound. This may be on by default and cannot be changed on your device.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device.can_set_surround_sound())
+                    && !device_supports(&device, |d| d.can_set_surround_sound()))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -97,7 +133,7 @@ fn main() {
                 .required(false)
                 .help("Mute or unmute playback.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device.can_set_silent_mode())
+                    && !device_supports(&device, |d| d.can_set_silent_mode()))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -106,10 +142,26 @@ fn main() {
                 .required(false)
                 .help("Activates noise gate.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device.can_set_silent_mode())
+                    && !device_supports(&device, |d| d.can_set_silent_mode()))
                 .value_parser(clap::value_parser!(bool)),
         )
+        .arg(
+            Arg::new("verbose")
+                .long("verbose")
+                .short('v')
+                .action(ArgAction::SetTrue)
+                .required(false)
+                .help("Use verbose output "),
+        )
         .get_matches();
+
+    let mut device = match device {
+        Ok(device) => device,
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1)
+        }
+    };
 
     let mut commands = Vec::new();
     if let Some(delay) = matches.get_one::<u8>("automatic_shutdown") {

--- a/src/devices/cloud_flight_wireless.rs
+++ b/src/devices/cloud_flight_wireless.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 const HP: u16 = 0x03F0;
 const HYPERX: u16 = 0x0951;
 pub const VENDOR_IDS: [u16; 2] = [HP, HYPERX];
-pub const PRODUCT_IDS: [u16; 2] = [0x0e90, 0x1749];
+pub const PRODUCT_IDS: [u16; 3] = [0x0e90, 0x1749, 0x16c4];
 
 const BASE_PACKET: [u8; 64] = {
     let mut packet = [0; 64];

--- a/src/devices/cloud_flight_wireless.rs
+++ b/src/devices/cloud_flight_wireless.rs
@@ -1,0 +1,174 @@
+use crate::{
+    debug_println,
+    devices::{ChargingStatus, Device, DeviceEvent, DeviceState},
+};
+use std::time::Duration;
+
+const HP: u16 = 0x03F0;
+pub const VENDOR_IDS: [u16; 1] = [HP];
+pub const PRODUCT_IDS: [u16; 1] = [0x0e90];
+
+const BASE_PACKET: [u8; 64] = {
+    let mut packet = [0; 64];
+    packet[0] = 33;
+    packet[1] = 255;
+    packet
+};
+
+const GET_BATTERY_CMD_ID: u8 = 5;
+
+pub struct CloudFlightWireless {
+    state: DeviceState,
+}
+
+impl CloudFlightWireless {
+    pub fn new_from_state(state: DeviceState) -> Self {
+        let mut state = state;
+        state.device_properties.connected = Some(true);
+        CloudFlightWireless { state }
+    }
+}
+
+const THRESHOLDS: [u16; 20] = [
+    3328, 3584, 3674, 3704, 3732, 3744, 3754, 3764, 3774, 3784, 3794, 3804, 3824, 3840, 3860, 3890,
+    3910, 3940, 3960, 3970,
+];
+
+const PERCENTAGES: [u8; 20] = [
+    5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100,
+];
+
+impl Device for CloudFlightWireless {
+    fn get_battery_packet(&self) -> Option<Vec<u8>> {
+        let mut tmp = BASE_PACKET.to_vec();
+        tmp[2] = GET_BATTERY_CMD_ID;
+        Some(tmp)
+    }
+
+    fn get_event_from_device_response(&self, response: &[u8]) -> Option<Vec<DeviceEvent>> {
+        debug_println!("Read packet: {:?}", response);
+        if response[0] != BASE_PACKET[0] || response[1] != BASE_PACKET[1] {
+            return None;
+        }
+        match response[2] {
+            GET_BATTERY_CMD_ID => {
+                let upper = response[3];
+                let lower = response[4];
+                let mut events = Vec::new();
+                if (upper == 16 && lower >= 20) || upper >= 17 {
+                    events.push(DeviceEvent::Charging(ChargingStatus::Charging));
+                } else {
+                    let index =
+                        match THRESHOLDS.binary_search(&(((upper as u16) << 8) | (lower as u16))) {
+                            Ok(i) => i,
+                            Err(0) => 0,
+                            Err(i) => i - 1,
+                        };
+                    events.push(DeviceEvent::BatterLevel(PERCENTAGES[index]));
+                    events.push(DeviceEvent::Charging(ChargingStatus::NotCharging));
+                }
+                Some(events)
+            }
+            _ => {
+                debug_println!("Unknown device event: {:?}", response);
+                None
+            }
+        }
+    }
+
+    fn get_device_state(&self) -> &DeviceState {
+        &self.state
+    }
+
+    fn get_device_state_mut(&mut self) -> &mut DeviceState {
+        &mut self.state
+    }
+
+    fn allow_passive_refresh(&mut self) -> bool {
+        true
+    }
+
+    fn get_charging_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn set_automatic_shut_down_packet(&self, _shutdown_after: Duration) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_automatic_shut_down_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_mute_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn set_mute_packet(&self, _mute: bool) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_surround_sound_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn set_surround_sound_packet(&self, _surround_sound: bool) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_mic_connected_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_pairing_info_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_product_color_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_side_tone_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn set_side_tone_packet(&self, _side_tone_on: bool) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_side_tone_volume_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn set_side_tone_volume_packet(&self, _volume: u8) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_voice_prompt_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn set_voice_prompt_packet(&self, _enable: bool) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_wireless_connected_status_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_sirk_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn reset_sirk_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn get_silent_mode_packet(&self) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn set_silent_mode_packet(&self, _silence: bool) -> Option<Vec<u8>> {
+        None
+    }
+}

--- a/src/devices/cloud_flight_wireless.rs
+++ b/src/devices/cloud_flight_wireless.rs
@@ -5,8 +5,9 @@ use crate::{
 use std::time::Duration;
 
 const HP: u16 = 0x03F0;
-pub const VENDOR_IDS: [u16; 1] = [HP];
-pub const PRODUCT_IDS: [u16; 1] = [0x0e90];
+const HYPERX: u16 = 0x0951;
+pub const VENDOR_IDS: [u16; 2] = [HP, HYPERX];
+pub const PRODUCT_IDS: [u16; 2] = [0x0e90, 0x1749];
 
 const BASE_PACKET: [u8; 64] = {
     let mut packet = [0; 64];

--- a/src/devices/cloud_flight_wireless.rs
+++ b/src/devices/cloud_flight_wireless.rs
@@ -16,6 +16,8 @@ const BASE_PACKET: [u8; 64] = {
     packet
 };
 
+const RESPONSE_POWER: u8 = 0x64;
+const RESPONSE_MUTE: u8 = 0x65;
 const GET_BATTERY_CMD_ID: u8 = 5;
 
 pub struct CloudFlightWireless {
@@ -48,11 +50,13 @@ impl Device for CloudFlightWireless {
 
     fn get_event_from_device_response(&self, response: &[u8]) -> Option<Vec<DeviceEvent>> {
         debug_println!("Read packet: {:?}", response);
-        if response[0] != BASE_PACKET[0] || response[1] != BASE_PACKET[1] {
-            return None;
-        }
-        match response[2] {
-            GET_BATTERY_CMD_ID => {
+        const BASE_0: u8 = BASE_PACKET[0];
+        const BASE_1: u8 = BASE_PACKET[1];
+        match (response[0], response[1], response[2]) {
+            (RESPONSE_POWER, 1, _) => Some(vec![DeviceEvent::WirelessConnected(true)]),
+            (RESPONSE_POWER, 3, _) => Some(vec![DeviceEvent::WirelessConnected(true)]),
+            (RESPONSE_MUTE, mute, _) => Some(vec![DeviceEvent::Muted(mute == 4)]),
+            (BASE_0, BASE_1, GET_BATTERY_CMD_ID) => {
                 let upper = response[3];
                 let lower = response[4];
                 let mut events = Vec::new();

--- a/src/devices/cloud_ii_wireless.rs
+++ b/src/devices/cloud_ii_wireless.rs
@@ -267,7 +267,7 @@ impl Device for CloudIIWireless {
         input_report_buffer[0] = 6;
         let _ = self
             .state
-            .hid_device
+            .transport
             .get_input_report(&mut input_report_buffer);
     }
 

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -52,6 +52,7 @@ const COLOR_COMMAND_ID: u8 = 0x4D;
 const CHARGE_STATE_COMMAND_ID: u8 = 0x48;
 const GET_MIC_MUTE_COMMAND_ID: u8 = 0x04;
 const GET_SIDE_TONE_COMMAND_ID: u8 = 0x16;
+const SET_SIDE_TONE_COMMAND_ID: u8 = 0x0D;
 const GET_AUTO_POWER_OFF_COMMAND_ID: u8 = 0x4B;
 const GET_VOICE_PROMPT_COMMAND_ID: u8 = 0x14;
 
@@ -210,8 +211,14 @@ impl Device for CloudIIISWireless {
         Some(packet)
     }
 
-    fn set_side_tone_packet(&self, _side_tone_on: bool) -> Option<Vec<u8>> {
-        None
+    fn set_side_tone_packet(&self, side_tone_on: bool) -> Option<Vec<u8>> {
+        // Confirmed via NGenuity USB capture: `0c 02 03 00 00 0d <0|1>`.
+        // byte[3] = 0x00 marks a SET (vs 0x01 for GET).
+        let mut packet = BASE_PACKET.to_vec();
+        packet[3] = 0x00;
+        packet[5] = SET_SIDE_TONE_COMMAND_ID;
+        packet[6] = side_tone_on as u8;
+        Some(packet)
     }
 
     fn get_side_tone_volume_packet(&self) -> Option<Vec<u8>> {

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -55,6 +55,7 @@ const GET_SIDE_TONE_COMMAND_ID: u8 = 0x16;
 const SET_SIDE_TONE_COMMAND_ID: u8 = 0x0D;
 const GET_AUTO_POWER_OFF_COMMAND_ID: u8 = 0x4B;
 const GET_VOICE_PROMPT_COMMAND_ID: u8 = 0x14;
+const SET_VOICE_PROMPT_COMMAND_ID: u8 = 0x0B;
 
 // Button report header (incoming from headset)
 const CONSUMER_CONTROL_HEADER: u8 = 0x0f;
@@ -235,8 +236,13 @@ impl Device for CloudIIISWireless {
         Some(packet)
     }
 
-    fn set_voice_prompt_packet(&self, _enable: bool) -> Option<Vec<u8>> {
-        None
+    fn set_voice_prompt_packet(&self, enable: bool) -> Option<Vec<u8>> {
+        // Confirmed via NGenuity USB capture: `0c 02 03 00 00 0b <0|1>`.
+        let mut packet = BASE_PACKET.to_vec();
+        packet[3] = 0x00;
+        packet[5] = SET_VOICE_PROMPT_COMMAND_ID;
+        packet[6] = enable as u8;
+        Some(packet)
     }
 
     fn get_wireless_connected_status_packet(&self) -> Option<Vec<u8>> {

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -213,8 +213,6 @@ impl Device for CloudIIISWireless {
     }
 
     fn set_side_tone_packet(&self, side_tone_on: bool) -> Option<Vec<u8>> {
-        // Confirmed via NGenuity USB capture: `0c 02 03 00 00 0d <0|1>`.
-        // byte[3] = 0x00 marks a SET (vs 0x01 for GET).
         let mut packet = BASE_PACKET.to_vec();
         packet[3] = 0x00;
         packet[5] = SET_SIDE_TONE_COMMAND_ID;
@@ -237,7 +235,6 @@ impl Device for CloudIIISWireless {
     }
 
     fn set_voice_prompt_packet(&self, enable: bool) -> Option<Vec<u8>> {
-        // Confirmed via NGenuity USB capture: `0c 02 03 00 00 0b <0|1>`.
         let mut packet = BASE_PACKET.to_vec();
         packet[3] = 0x00;
         packet[5] = SET_VOICE_PROMPT_COMMAND_ID;

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -1,5 +1,3 @@
-use hidapi::HidError;
-
 use crate::{
     debug_println,
     devices::{ChargingStatus, Color, Device, DeviceEvent, DeviceState},
@@ -149,11 +147,13 @@ impl CloudIIISWireless {
 }
 
 impl Device for CloudIIISWireless {
-    fn write_hid_report(&mut self, packet: &[u8]) -> Result<(), HidError> {
-        self.get_device_state_mut()
-            .hid_device
-            .send_feature_report(packet)
-    }
+    // Use the default `write_hid_report` from the `Device` trait, which calls
+    // `hid_device.write()`. The Cloud III S HID interface has no OUT endpoint, so writes
+    // become `SET_REPORT` control transfers with report type **Output**, which is what the
+    // Ngenuity application uses (and what the device firmware listens for on Report ID 0x0c).
+    // The previous override forced `send_feature_report` (type **Feature**), which the device
+    // silently ignores — the symptom was that battery / connection / side tone queries never
+    // produced a response.
 
     fn get_charging_packet(&self) -> Option<Vec<u8>> {
         let mut packet = BASE_PACKET.to_vec();

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -15,15 +15,12 @@ const HP: u16 = 0x03F0;
 pub const VENDOR_IDS: [u16; 1] = [HP];
 pub const PRODUCT_IDS: [u16; 1] = [0x06BE];
 
-// Cloud III S uses a different protocol than Cloud III
-// Header 0x05 for mic control, 20-byte packets
-const PACKET_SIZE: usize = 20;
+// Mic state reports: the headset sometimes sends spontaneous reports on
+// Report ID 0x05 (e.g. on boom-mic flip). We don't write to this report ID
+// — mute is set via the 0x0c-protocol cmd 0x01 (see `set_mute_packet`) —
+// but we still parse incoming reports so the menu reflects hardware-driven
+// state changes. Pattern: `(byte[1] & 0x02) != 0` means muted.
 const MIC_HEADER: u8 = 0x05;
-
-// Mic control commands (byte 1 after header)
-// Pattern: (cmd & 0x02) == 0 means ON
-const MIC_ON_CMD: u8 = 0x00;
-const MIC_OFF_CMD: u8 = 0x02;
 
 // Auto-shutdown control (via SET_REPORT, report ID 0x0c)
 // Packet structure: 0c 02 03 00 00 4a XX 00... (64 bytes total)
@@ -58,6 +55,7 @@ const DONGLE_CONNECTED_COMMAND_ID: u8 = 0x02;
 const COLOR_COMMAND_ID: u8 = 0x4D;
 const CHARGE_STATE_COMMAND_ID: u8 = 0x48;
 const GET_MIC_MUTE_COMMAND_ID: u8 = 0x04;
+const SET_MIC_MUTE_COMMAND_ID: u8 = 0x01;
 const GET_SIDE_TONE_COMMAND_ID: u8 = 0x16;
 const GET_AUTO_POWER_OFF_COMMAND_ID: u8 = 0x4B;
 const GET_VOICE_PROMPT_COMMAND_ID: u8 = 0x14;
@@ -76,13 +74,6 @@ const PLAY_PAUSE: u8 = 0x08;
 const HID_INTERFACE: u8 = 3;
 #[cfg(target_os = "linux")]
 const HID_EP_IN: u8 = 0x84;
-
-fn make_mic_packet(mute: bool) -> Vec<u8> {
-    let mut packet = vec![0u8; PACKET_SIZE];
-    packet[0] = MIC_HEADER;
-    packet[1] = if mute { MIC_OFF_CMD } else { MIC_ON_CMD };
-    packet
-}
 
 fn make_auto_shutdown_packet(minutes: u64) -> Vec<u8> {
     let mut packet = vec![0u8; AUTO_SHUTDOWN_PACKET_SIZE];
@@ -200,9 +191,16 @@ impl Device for CloudIIISWireless {
         Some(packet)
     }
 
-    // Cloud III S: Mic control - CONFIRMED WORKING
+    // Mic mute via the 0x0c-report protocol (cmd 0x01). Confirmed by NGenuity
+    // capture : `0c 02 03 00 00 01 <0|1>`,
+    // value 1 = muted, 0 = unmuted. Acknowledged by the device with notification
+    // ID 3 (`0d 02 03 00 03 <val>`) which `parse_notification` already handles.
     fn set_mute_packet(&self, mute: bool) -> Option<Vec<u8>> {
-        Some(make_mic_packet(mute))
+        let mut packet = BASE_PACKET.to_vec();
+        packet[3] = 0x00;
+        packet[5] = SET_MIC_MUTE_COMMAND_ID;
+        packet[6] = mute as u8;
+        Some(packet)
     }
 
     fn get_surround_sound_packet(&self) -> Option<Vec<u8>> {

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -4,6 +4,13 @@ use crate::{
 };
 use std::time::Duration;
 
+#[cfg(target_os = "linux")]
+use crate::devices::{
+    DeviceError, DeviceProperties, HidTransport, LibusbTransport,
+};
+#[cfg(target_os = "linux")]
+use rusb::UsbContext;
+
 const HP: u16 = 0x03F0;
 pub const VENDOR_IDS: [u16; 1] = [HP];
 pub const PRODUCT_IDS: [u16; 1] = [0x06BE];
@@ -58,9 +65,17 @@ const GET_VOICE_PROMPT_COMMAND_ID: u8 = 0x14;
 // Button report header (incoming from headset)
 const CONSUMER_CONTROL_HEADER: u8 = 0x0f;
 // Consumer control button values
-const _VOL_UP: u8 = 0x01;
-const _VOL_DOWN: u8 = 0x02;
-const _PLAY_PAUSE: u8 = 0x08;
+const VOL_UP: u8 = 0x01;
+const VOL_DOWN: u8 = 0x02;
+const PLAY_PAUSE: u8 = 0x08;
+
+// HID interface exposed by the dongle. The dongle has only one HID interface
+// (`bInterfaceNumber = 3`) with a single INTERRUPT IN endpoint at `0x84`; all
+// writes are SET_REPORT class control transfers.
+#[cfg(target_os = "linux")]
+const HID_INTERFACE: u8 = 3;
+#[cfg(target_os = "linux")]
+const HID_EP_IN: u8 = 0x84;
 
 fn make_mic_packet(mute: bool) -> Vec<u8> {
     let mut packet = vec![0u8; PACKET_SIZE];
@@ -308,4 +323,109 @@ impl Device for CloudIIISWireless {
     fn get_device_state_mut(&mut self) -> &mut DeviceState {
         &mut self.state
     }
+}
+
+/// Open the dongle via libusb instead of hidapi/hidraw.
+///
+/// On Linux, once the kernel hidraw driver has touched this dongle's HID
+/// interface, RF-forwarded query responses (battery, charge, side tone, etc.)
+/// silently stop reaching user space. Going via libusb — detach the kernel
+/// driver, claim the interface exclusively, drive raw SET_REPORT control
+/// transfers + INT IN reads ourselves — sidesteps the issue and gives reliable
+/// bidirectional traffic.
+///
+/// Linux-only: the firmware quirk has only been observed on Linux's hidraw
+/// stack, and the kernel-driver-detach pattern is meaningful only there.
+#[cfg(target_os = "linux")]
+pub fn open_via_libusb() -> Result<Option<DeviceState>, DeviceError> {
+    let ctx = match rusb::Context::new() {
+        Ok(c) => c,
+        Err(_e) => {
+            debug_println!("libusb Context::new failed: {_e}");
+            return Ok(None);
+        }
+    };
+    let devices = match ctx.devices() {
+        Ok(d) => d,
+        Err(_e) => {
+            debug_println!("libusb devices() failed: {_e}");
+            return Ok(None);
+        }
+    };
+    let want_vid = VENDOR_IDS[0];
+    let want_pid = PRODUCT_IDS[0];
+    let dev = devices.iter().find(|d| {
+        d.device_descriptor()
+            .map(|desc| desc.vendor_id() == want_vid && desc.product_id() == want_pid)
+            .unwrap_or(false)
+    });
+    let Some(dev) = dev else {
+        return Ok(None);
+    };
+    let handle = match dev.open() {
+        Ok(h) => h,
+        Err(_e) => {
+            debug_println!("libusb open failed: {_e}");
+            return Ok(None);
+        }
+    };
+
+    if handle
+        .kernel_driver_active(HID_INTERFACE)
+        .unwrap_or(false)
+    {
+        if let Err(_e) = handle.detach_kernel_driver(HID_INTERFACE) {
+            debug_println!("detach_kernel_driver: {_e}");
+        }
+    }
+    if let Err(_e) = handle.claim_interface(HID_INTERFACE) {
+        debug_println!("claim_interface: {_e}");
+        let _ = handle.attach_kernel_driver(HID_INTERFACE);
+        return Ok(None);
+    }
+
+    let product_string = handle
+        .read_product_string_ascii(
+            &dev.device_descriptor()
+                .map_err(|_| DeviceError::NoDeviceFound())?,
+        )
+        .ok();
+
+    // Forward Consumer Control reports (vol-up / vol-down / play-pause) back
+    // to the OS via synthesized media key presses. With the kernel HID driver
+    // detached, the input subsystem no longer sees these events on its own.
+    //
+    // Caveat: on Wayland this depends on the compositor accepting input
+    // emulation through libei (`xdg-desktop-portal-*`). On compositors that
+    // don't, the synthetic events are silently dropped and the headset's
+    // volume / play-pause buttons stay inert while this program runs. Works
+    // out of the box on X11.
+    use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+    let mut enigo = match Enigo::new(&Settings::default()) {
+        Ok(e) => Some(e),
+        Err(e) => {
+            eprintln!("Cloud III S: input forwarding disabled (enigo init: {e})");
+            None
+        }
+    };
+    let packet_hook = Box::new(move |buf: &[u8]| {
+        if buf.len() >= 2 && buf[0] == CONSUMER_CONTROL_HEADER {
+            let key = match buf[1] {
+                VOL_UP => Some(Key::VolumeUp),
+                VOL_DOWN => Some(Key::VolumeDown),
+                PLAY_PAUSE => Some(Key::MediaPlayPause),
+                _ => None,
+            };
+            if let (Some(k), Some(e)) = (key, enigo.as_mut()) {
+                let _ = e.key(k, Direction::Click);
+            }
+        }
+    });
+
+    let transport =
+        LibusbTransport::open(handle, HID_INTERFACE, HID_EP_IN, product_string.clone(), packet_hook);
+    Ok(Some(DeviceState {
+        transport: HidTransport::Libusb(transport),
+        device_properties: DeviceProperties::new(want_pid, want_vid, product_string),
+    }))
 }

--- a/src/devices/cloud_iii_s_wireless.rs
+++ b/src/devices/cloud_iii_s_wireless.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 const HP: u16 = 0x03F0;
 pub const VENDOR_IDS: [u16; 1] = [HP];
-pub const PRODUCT_IDS: [u16; 1] = [0x06BE];
+pub const PRODUCT_IDS: [u16; 2] = [0x06BE, 0x02CC];
 
 // Cloud III S uses a different protocol than Cloud III
 // Header 0x05 for mic control, 20-byte packets

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     },
 };
 use hidapi::{HidApi, HidDevice, HidError};
+use rusb::UsbContext;
 use std::{
     collections::HashSet,
     fmt::{Debug, Display},
@@ -22,6 +23,146 @@ use std::{
 use thistermination::TerminationFull;
 
 const PASSIVE_REFRESH_TIME_OUT: Duration = Duration::from_secs(2);
+
+/// HID interface exposed by the Cloud III S Wireless dongle. The dongle has
+/// only one HID interface (`bInterfaceNumber = 3`) with a single INTERRUPT IN
+/// endpoint at `0x84`; all writes are SET_REPORT class control transfers.
+const CLOUD_III_S_HID_INTERFACE: u8 = 3;
+const CLOUD_III_S_HID_EP_IN: u8 = 0x84;
+
+fn open_cloud_iii_s_via_libusb() -> Result<Option<DeviceState>, DeviceError> {
+    let ctx = match rusb::Context::new() {
+        Ok(c) => c,
+        Err(_e) => {
+            debug_println!("libusb Context::new failed: {_e}");
+            return Ok(None);
+        }
+    };
+    let devices = match ctx.devices() {
+        Ok(d) => d,
+        Err(_e) => {
+            debug_println!("libusb devices() failed: {_e}");
+            return Ok(None);
+        }
+    };
+    let want_vid = cloud_iii_s_wireless::VENDOR_IDS[0];
+    let want_pid = cloud_iii_s_wireless::PRODUCT_IDS[0];
+    let dev = devices.iter().find(|d| {
+        d.device_descriptor()
+            .map(|desc| desc.vendor_id() == want_vid && desc.product_id() == want_pid)
+            .unwrap_or(false)
+    });
+    let Some(dev) = dev else {
+        return Ok(None);
+    };
+    let handle = match dev.open() {
+        Ok(h) => h,
+        Err(_e) => {
+            debug_println!("Cloud III S: libusb open failed: {_e}");
+            return Ok(None);
+        }
+    };
+
+    // Best-effort detach the kernel HID driver so we can claim the interface
+    // exclusively. On non-Linux this is a no-op.
+    if handle
+        .kernel_driver_active(CLOUD_III_S_HID_INTERFACE)
+        .unwrap_or(false)
+    {
+        if let Err(_e) = handle.detach_kernel_driver(CLOUD_III_S_HID_INTERFACE) {
+            debug_println!("Cloud III S: detach_kernel_driver: {_e}");
+        }
+    }
+    if let Err(_e) = handle.claim_interface(CLOUD_III_S_HID_INTERFACE) {
+        debug_println!("Cloud III S: claim_interface: {_e}");
+        let _ = handle.attach_kernel_driver(CLOUD_III_S_HID_INTERFACE);
+        return Ok(None);
+    }
+
+    let product_string = handle
+        .read_product_string_ascii(&dev.device_descriptor().map_err(|_| DeviceError::NoDeviceFound())?)
+        .ok();
+
+    let handle = std::sync::Arc::new(handle);
+    let rx = std::sync::Arc::new((
+        std::sync::Mutex::new(std::collections::VecDeque::new()),
+        std::sync::Condvar::new(),
+    ));
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    // Background reader: continuously poll EP IN with a short timeout. Push every
+    // received packet into the shared queue so callers see responses even when the
+    // surrounding flow does a `write → sleep → read` (active_refresh_state).
+    let reader = {
+        let handle = std::sync::Arc::clone(&handle);
+        let rx = std::sync::Arc::clone(&rx);
+        let stop = std::sync::Arc::clone(&stop);
+        std::thread::spawn(move || {
+            // Forwarding Consumer Control events (Report ID 0x0f, vol-up / vol-down /
+            // play-pause buttons on the headset) back to the OS. With the kernel HID
+            // driver detached, the input subsystem no longer sees them, so we
+            // synthesize the corresponding media key presses with `enigo`.
+            //
+            // Caveat: on Linux/Wayland this depends on the compositor accepting input
+            // emulation through libei (`xdg-desktop-portal-*`). On compositors that
+            // don't, the synthetic events are silently dropped and the headset's
+            // volume / play-pause buttons stay inert while this program runs. Works
+            // out of the box on X11.
+            use enigo::{Direction, Enigo, Key, Keyboard, Settings};
+            let mut enigo = match Enigo::new(&Settings::default()) {
+                Ok(e) => Some(e),
+                Err(e) => {
+                    eprintln!("Cloud III S: input forwarding disabled (enigo init: {e})");
+                    None
+                }
+            };
+            let mut buf = [0u8; 64];
+            while !stop.load(std::sync::atomic::Ordering::SeqCst) {
+                match handle.read_interrupt(
+                    CLOUD_III_S_HID_EP_IN,
+                    &mut buf,
+                    Duration::from_millis(100),
+                ) {
+                    Ok(n) if n > 0 => {
+                        if n >= 2 && buf[0] == 0x0f {
+                            let key = match buf[1] {
+                                0x01 => Some(Key::VolumeUp),
+                                0x02 => Some(Key::VolumeDown),
+                                0x08 => Some(Key::MediaPlayPause),
+                                _ => None,
+                            };
+                            if let (Some(k), Some(e)) = (key, enigo.as_mut()) {
+                                let _ = e.key(k, Direction::Click);
+                            }
+                        }
+                        let (lock, cvar) = &*rx;
+                        let mut q = lock.lock().unwrap();
+                        q.push_back(buf[..n].to_vec());
+                        cvar.notify_one();
+                    }
+                    Ok(_) => {}
+                    Err(rusb::Error::Timeout) => {}
+                    Err(rusb::Error::NoDevice) | Err(rusb::Error::Pipe) => break,
+                    Err(_) => {}
+                }
+            }
+        })
+    };
+
+    let transport = LibusbTransport {
+        handle,
+        interface: CLOUD_III_S_HID_INTERFACE,
+        ep_in: CLOUD_III_S_HID_EP_IN,
+        product_string: product_string.clone(),
+        rx,
+        stop,
+        reader: Some(reader),
+    };
+    Ok(Some(DeviceState {
+        transport: HidTransport::Libusb(transport),
+        device_properties: DeviceProperties::new(want_pid, want_vid, product_string),
+    }))
+}
 
 type DeviceFactory = fn(DeviceState) -> Box<dyn Device>;
 
@@ -130,10 +271,15 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
             let mut test_device = (entry.factory)(state);
             test_device.init_capabilities();
 
+            // Use the wireless-connected query as the probe: it is the cheapest one
+            // and the one most consistently answered by the dongle from its local cache
+            // (no RF round-trip to the headset required). Some devices (e.g. Cloud III S
+            // Wireless) won't answer the battery query when the headset isn't actively
+            // using the audio link, so probing on battery would falsely fail.
             let probe_packet = test_device
                 .get_query_packets()
                 .into_iter()
-                .nth(2)
+                .next()
                 .expect("Why is there a device without packets ???");
 
             test_device.prepare_write();
@@ -144,8 +290,8 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
                 std::thread::sleep(RESPONSE_DELAY);
 
                 if let Some(events) = test_device.wait_for_updates(Duration::from_secs(1)) {
-                    for event in events {
-                        debug_println!("got response {event:?}");
+                    for _event in events {
+                        debug_println!("got response {_event:?}");
                     }
                 } else {
                     continue;
@@ -161,8 +307,177 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
 
 #[derive(Debug)]
 pub struct DeviceState {
-    pub hid_device: HidDevice,
+    pub transport: HidTransport,
     pub device_properties: DeviceProperties,
+}
+
+/// HID transport abstraction. Most devices use `Hidapi` (the `hidapi-rs` library
+/// which talks to `/dev/hidrawN` on Linux). The `Libusb` variant is for devices
+/// that need direct USB access — specifically the Cloud III S Wireless on
+/// firmware ≥ 0x4118, where the kernel hidraw stack causes RF-forwarded query
+/// responses to be lost. With `Libusb` we detach the kernel driver, claim the
+/// HID interface exclusively, and issue raw SET_REPORT class control transfers
+/// + INT IN reads ourselves.
+pub enum HidTransport {
+    Hidapi(HidDevice),
+    Libusb(LibusbTransport),
+}
+
+pub struct LibusbTransport {
+    handle: std::sync::Arc<rusb::DeviceHandle<rusb::Context>>,
+    interface: u8,
+    ep_in: u8,
+    product_string: Option<String>,
+    rx: std::sync::Arc<(std::sync::Mutex<std::collections::VecDeque<Vec<u8>>>, std::sync::Condvar)>,
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    reader: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Debug for HidTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HidTransport::Hidapi(_) => f.write_str("HidTransport::Hidapi(..)"),
+            HidTransport::Libusb(t) => f
+                .debug_struct("HidTransport::Libusb")
+                .field("interface", &t.interface)
+                .field("ep_in", &format_args!("0x{:02x}", t.ep_in))
+                .finish(),
+        }
+    }
+}
+
+const HID_REQ_GET_REPORT: u8 = 0x01;
+const HID_REQ_SET_REPORT: u8 = 0x09;
+const HID_REPORT_TYPE_INPUT: u16 = 0x01;
+const HID_REPORT_TYPE_OUTPUT: u16 = 0x02;
+const HID_REPORT_TYPE_FEATURE: u16 = 0x03;
+
+impl HidTransport {
+    pub fn write(&self, data: &[u8]) -> Result<usize, HidError> {
+        match self {
+            HidTransport::Hidapi(d) => d.write(data),
+            HidTransport::Libusb(t) => t.set_report(HID_REPORT_TYPE_OUTPUT, data),
+        }
+    }
+
+    pub fn read_timeout(&self, buf: &mut [u8], timeout_ms: i32) -> Result<usize, HidError> {
+        match self {
+            HidTransport::Hidapi(d) => d.read_timeout(buf, timeout_ms),
+            HidTransport::Libusb(t) => t.read_interrupt(buf, timeout_ms),
+        }
+    }
+
+    pub fn send_feature_report(&self, data: &[u8]) -> Result<(), HidError> {
+        match self {
+            HidTransport::Hidapi(d) => d.send_feature_report(data),
+            HidTransport::Libusb(t) => t.set_report(HID_REPORT_TYPE_FEATURE, data).map(|_| ()),
+        }
+    }
+
+    pub fn get_input_report(&self, buf: &mut [u8]) -> Result<usize, HidError> {
+        match self {
+            HidTransport::Hidapi(d) => d.get_input_report(buf),
+            HidTransport::Libusb(t) => t.get_report(HID_REPORT_TYPE_INPUT, buf),
+        }
+    }
+
+    pub fn product_string(&self) -> Option<String> {
+        match self {
+            HidTransport::Hidapi(d) => d.get_product_string().ok().flatten(),
+            HidTransport::Libusb(t) => t.product_string.clone(),
+        }
+    }
+}
+
+fn rusb_to_hid(err: rusb::Error) -> HidError {
+    HidError::HidApiError {
+        message: format!("libusb: {err}"),
+    }
+}
+
+impl LibusbTransport {
+    fn set_report(&self, report_type: u16, data: &[u8]) -> Result<usize, HidError> {
+        if data.is_empty() {
+            return Err(HidError::InvalidZeroSizeData);
+        }
+        let report_id = data[0];
+        let request_type = rusb::request_type(
+            rusb::Direction::Out,
+            rusb::RequestType::Class,
+            rusb::Recipient::Interface,
+        );
+        let wvalue = (report_type << 8) | (report_id as u16);
+        self.handle
+            .write_control(
+                request_type,
+                HID_REQ_SET_REPORT,
+                wvalue,
+                self.interface as u16,
+                data,
+                Duration::from_millis(500),
+            )
+            .map_err(rusb_to_hid)
+    }
+
+    fn get_report(&self, report_type: u16, buf: &mut [u8]) -> Result<usize, HidError> {
+        if buf.is_empty() {
+            return Err(HidError::InvalidZeroSizeData);
+        }
+        let report_id = buf[0];
+        let request_type = rusb::request_type(
+            rusb::Direction::In,
+            rusb::RequestType::Class,
+            rusb::Recipient::Interface,
+        );
+        let wvalue = (report_type << 8) | (report_id as u16);
+        self.handle
+            .read_control(
+                request_type,
+                HID_REQ_GET_REPORT,
+                wvalue,
+                self.interface as u16,
+                buf,
+                Duration::from_millis(500),
+            )
+            .map_err(rusb_to_hid)
+    }
+
+    fn read_interrupt(&self, buf: &mut [u8], timeout_ms: i32) -> Result<usize, HidError> {
+        // Pop from the background-reader queue. This decouples USB polling from
+        // user calls so a `write` followed by a `sleep` followed by a `read` still
+        // captures any response that arrived during the sleep.
+        let timeout = if timeout_ms < 0 {
+            Duration::from_secs(60 * 60)
+        } else {
+            Duration::from_millis(timeout_ms as u64)
+        };
+        let (lock, cvar) = &*self.rx;
+        let deadline = std::time::Instant::now() + timeout;
+        let mut q = lock.lock().unwrap();
+        while q.is_empty() {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return Ok(0);
+            }
+            let (g, _) = cvar.wait_timeout(q, deadline - now).unwrap();
+            q = g;
+        }
+        let pkt = q.pop_front().unwrap();
+        let n = pkt.len().min(buf.len());
+        buf[..n].copy_from_slice(&pkt[..n]);
+        Ok(n)
+    }
+}
+
+impl Drop for LibusbTransport {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Some(t) = self.reader.take() {
+            let _ = t.join();
+        }
+        let _ = self.handle.release_interface(self.interface);
+        let _ = self.handle.attach_kernel_driver(self.interface);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -204,6 +519,19 @@ impl Display for DeviceProperties {
 
 impl DeviceState {
     pub fn new(product_ids: &[u16], vendor_ids: &[u16]) -> Result<Vec<Self>, DeviceError> {
+        // Cloud III S Wireless: open via libusb FIRST, before any hidapi/hidraw
+        // enumeration. The kernel hidraw driver, once it has touched the dongle's
+        // HID interface, leaves the INT IN URB queue in a state where responses
+        // never reach a subsequent libusb claim. Doing libusb first (and keeping
+        // it claimed) sidesteps the race.
+        let cloud_iii_s_state = if vendor_ids.contains(&cloud_iii_s_wireless::VENDOR_IDS[0])
+            && product_ids.contains(&cloud_iii_s_wireless::PRODUCT_IDS[0])
+        {
+            open_cloud_iii_s_via_libusb()?
+        } else {
+            None
+        };
+
         let hid_api = HidApi::new()?;
         let mut potential_devices = HashSet::new();
         let mut error = Ok(());
@@ -218,6 +546,14 @@ impl DeviceState {
         let device_candidates: Vec<(HidDevice, u16, u16)> = hid_api
             .device_list()
             .filter_map(|info| {
+                // Skip Cloud III S: opened via libusb separately below. Letting
+                // hidapi-hidraw open `/dev/hidraw*` here would race with our
+                // detach_kernel_driver/claim_interface call.
+                if info.vendor_id() == cloud_iii_s_wireless::VENDOR_IDS[0]
+                    && info.product_id() == cloud_iii_s_wireless::PRODUCT_IDS[0]
+                {
+                    return None;
+                }
                 if product_ids.contains(&info.product_id())
                     && vendor_ids.contains(&info.vendor_id())
                 {
@@ -256,7 +592,7 @@ impl DeviceState {
             })
             .collect();
 
-        if device_candidates.is_empty() {
+        if device_candidates.is_empty() && cloud_iii_s_state.is_none() {
             if !potential_devices.is_empty() {
                 let names = potential_devices
                     .iter()
@@ -280,16 +616,20 @@ impl DeviceState {
             return Err(DeviceError::NoDeviceFound());
         }
 
-        Ok(device_candidates
+        let mut states: Vec<DeviceState> = device_candidates
             .into_iter()
             .map(|(hid_device, product_id, vendor_id)| {
                 let device_name = hid_device.get_product_string().ok().flatten();
                 DeviceState {
-                    hid_device,
+                    transport: HidTransport::Hidapi(hid_device),
                     device_properties: DeviceProperties::new(product_id, vendor_id, device_name),
                 }
             })
-            .collect())
+            .collect();
+        if let Some(state) = cloud_iii_s_state {
+            states.insert(0, state);
+        }
+        Ok(states)
     }
 
     fn update_self_with_event(&mut self, event: &DeviceEvent) {
@@ -726,7 +1066,7 @@ pub trait Device {
     /// Adapted from PR #20 by @navrozashvili
     /// Source: https://github.com/LennardKittner/HyperHeadset/pull/20
     fn write_hid_report(&mut self, packet: &[u8]) -> Result<(), HidError> {
-        match self.get_device_state_mut().hid_device.write(packet) {
+        match self.get_device_state_mut().transport.write(packet) {
             Ok(_) => Ok(()),
             Err(write_err) => {
                 #[cfg(target_os = "windows")]
@@ -741,7 +1081,7 @@ pub trait Device {
                             // write() error since that's what callers attempted.
                             if let Err(_feature_err) = self
                                 .get_device_state_mut()
-                                .hid_device
+                                .transport
                                 .send_feature_report(packet)
                             {
                                 return Err(write_err);
@@ -862,7 +1202,7 @@ pub trait Device {
         let mut buf = self.get_response_buffer();
         let res = self
             .get_device_state()
-            .hid_device
+            .transport
             .read_timeout(&mut buf[..], duration.as_millis() as i32)
             .ok()?;
 

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -156,15 +156,10 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
             let mut test_device = (entry.factory)(state);
             test_device.init_capabilities();
 
-            // Use the wireless-connected query as the probe: it is the cheapest one
-            // and the one most consistently answered by the dongle from its local cache
-            // (no RF round-trip to the headset required). Some devices (e.g. Cloud III S
-            // Wireless) won't answer the battery query when the headset isn't actively
-            // using the audio link, so probing on battery would falsely fail.
             let probe_packet = test_device
                 .get_query_packets()
                 .into_iter()
-                .next()
+                .nth(2)
                 .expect("Why is there a device without packets ???");
 
             test_device.prepare_write();

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -80,34 +80,34 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
     debug_println!("Found device selecting handler");
 
     // On Linux and MacOS we can just take the first
-    #[cfg(not(target_os = "windows"))]
-    {
-        let state = states
-            .into_iter()
-            .next()
-            .ok_or(DeviceError::NoDeviceFound())?;
-        println!(
-            "Connecting to {}",
-            state
-                .device_properties
-                .device_name
-                .clone()
-                .unwrap_or("???".to_string())
-        );
-        let entry = DEVICE_REGISTER
-            .iter()
-            .find(|e| {
-                e.vendor_ids.contains(&state.device_properties.vendor_id)
-                    && e.product_ids.contains(&state.device_properties.product_id)
-            })
-            .ok_or(DeviceError::NoDeviceFound())?;
-
-        let mut device = (entry.factory)(state);
-        device.init_capabilities();
-        Ok(device)
-    }
+    // #[cfg(not(target_os = "windows"))]
+    // {
+    //     let state = states
+    //         .into_iter()
+    //         .next()
+    //         .ok_or(DeviceError::NoDeviceFound())?;
+    //     println!(
+    //         "Connecting to {}",
+    //         state
+    //             .device_properties
+    //             .device_name
+    //             .clone()
+    //             .unwrap_or("???".to_string())
+    //     );
+    //     let entry = DEVICE_REGISTER
+    //         .iter()
+    //         .find(|e| {
+    //             e.vendor_ids.contains(&state.device_properties.vendor_id)
+    //                 && e.product_ids.contains(&state.device_properties.product_id)
+    //         })
+    //         .ok_or(DeviceError::NoDeviceFound())?;
+    //
+    //     let mut device = (entry.factory)(state);
+    //     device.init_capabilities();
+    //     Ok(device)
+    // }
     // On Windows we have to check which interface can be used
-    #[cfg(target_os = "windows")]
+    // #[cfg(target_os = "windows")]
     {
         let mut device = None;
         for state in states {
@@ -133,7 +133,7 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
             let probe_packet = test_device
                 .get_query_packets()
                 .into_iter()
-                .next()
+                .nth(2)
                 .expect("Why is there a device without packets ???");
 
             test_device.prepare_write();
@@ -144,6 +144,16 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
                 debug_println!("Failed to open: {_e:?}");
                 continue;
             } else {
+                std::thread::sleep(RESPONSE_DELAY);
+
+                if let Some(events) = test_device.wait_for_updates(Duration::from_secs(1)) {
+                    for event in events {
+                        debug_println!("got response {event:?}");
+                    }
+                } else {
+                    continue;
+                }
+
                 device = Some(test_device);
                 break;
             }

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -14,7 +14,6 @@ use crate::{
     },
 };
 use hidapi::{HidApi, HidDevice, HidError};
-use rusb::UsbContext;
 use std::{
     collections::HashSet,
     fmt::{Debug, Display},
@@ -24,186 +23,72 @@ use thistermination::TerminationFull;
 
 const PASSIVE_REFRESH_TIME_OUT: Duration = Duration::from_secs(2);
 
-/// HID interface exposed by the Cloud III S Wireless dongle. The dongle has
-/// only one HID interface (`bInterfaceNumber = 3`) with a single INTERRUPT IN
-/// endpoint at `0x84`; all writes are SET_REPORT class control transfers.
-const CLOUD_III_S_HID_INTERFACE: u8 = 3;
-const CLOUD_III_S_HID_EP_IN: u8 = 0x84;
-
-fn open_cloud_iii_s_via_libusb() -> Result<Option<DeviceState>, DeviceError> {
-    let ctx = match rusb::Context::new() {
-        Ok(c) => c,
-        Err(_e) => {
-            debug_println!("libusb Context::new failed: {_e}");
-            return Ok(None);
-        }
-    };
-    let devices = match ctx.devices() {
-        Ok(d) => d,
-        Err(_e) => {
-            debug_println!("libusb devices() failed: {_e}");
-            return Ok(None);
-        }
-    };
-    let want_vid = cloud_iii_s_wireless::VENDOR_IDS[0];
-    let want_pid = cloud_iii_s_wireless::PRODUCT_IDS[0];
-    let dev = devices.iter().find(|d| {
-        d.device_descriptor()
-            .map(|desc| desc.vendor_id() == want_vid && desc.product_id() == want_pid)
-            .unwrap_or(false)
-    });
-    let Some(dev) = dev else {
-        return Ok(None);
-    };
-    let handle = match dev.open() {
-        Ok(h) => h,
-        Err(_e) => {
-            debug_println!("Cloud III S: libusb open failed: {_e}");
-            return Ok(None);
-        }
-    };
-
-    // Best-effort detach the kernel HID driver so we can claim the interface
-    // exclusively. On non-Linux this is a no-op.
-    if handle
-        .kernel_driver_active(CLOUD_III_S_HID_INTERFACE)
-        .unwrap_or(false)
-    {
-        if let Err(_e) = handle.detach_kernel_driver(CLOUD_III_S_HID_INTERFACE) {
-            debug_println!("Cloud III S: detach_kernel_driver: {_e}");
-        }
-    }
-    if let Err(_e) = handle.claim_interface(CLOUD_III_S_HID_INTERFACE) {
-        debug_println!("Cloud III S: claim_interface: {_e}");
-        let _ = handle.attach_kernel_driver(CLOUD_III_S_HID_INTERFACE);
-        return Ok(None);
-    }
-
-    let product_string = handle
-        .read_product_string_ascii(&dev.device_descriptor().map_err(|_| DeviceError::NoDeviceFound())?)
-        .ok();
-
-    let handle = std::sync::Arc::new(handle);
-    let rx = std::sync::Arc::new((
-        std::sync::Mutex::new(std::collections::VecDeque::new()),
-        std::sync::Condvar::new(),
-    ));
-    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-
-    // Background reader: continuously poll EP IN with a short timeout. Push every
-    // received packet into the shared queue so callers see responses even when the
-    // surrounding flow does a `write → sleep → read` (active_refresh_state).
-    let reader = {
-        let handle = std::sync::Arc::clone(&handle);
-        let rx = std::sync::Arc::clone(&rx);
-        let stop = std::sync::Arc::clone(&stop);
-        std::thread::spawn(move || {
-            // Forwarding Consumer Control events (Report ID 0x0f, vol-up / vol-down /
-            // play-pause buttons on the headset) back to the OS. With the kernel HID
-            // driver detached, the input subsystem no longer sees them, so we
-            // synthesize the corresponding media key presses with `enigo`.
-            //
-            // Caveat: on Linux/Wayland this depends on the compositor accepting input
-            // emulation through libei (`xdg-desktop-portal-*`). On compositors that
-            // don't, the synthetic events are silently dropped and the headset's
-            // volume / play-pause buttons stay inert while this program runs. Works
-            // out of the box on X11.
-            use enigo::{Direction, Enigo, Key, Keyboard, Settings};
-            let mut enigo = match Enigo::new(&Settings::default()) {
-                Ok(e) => Some(e),
-                Err(e) => {
-                    eprintln!("Cloud III S: input forwarding disabled (enigo init: {e})");
-                    None
-                }
-            };
-            let mut buf = [0u8; 64];
-            while !stop.load(std::sync::atomic::Ordering::SeqCst) {
-                match handle.read_interrupt(
-                    CLOUD_III_S_HID_EP_IN,
-                    &mut buf,
-                    Duration::from_millis(100),
-                ) {
-                    Ok(n) if n > 0 => {
-                        if n >= 2 && buf[0] == 0x0f {
-                            let key = match buf[1] {
-                                0x01 => Some(Key::VolumeUp),
-                                0x02 => Some(Key::VolumeDown),
-                                0x08 => Some(Key::MediaPlayPause),
-                                _ => None,
-                            };
-                            if let (Some(k), Some(e)) = (key, enigo.as_mut()) {
-                                let _ = e.key(k, Direction::Click);
-                            }
-                        }
-                        let (lock, cvar) = &*rx;
-                        let mut q = lock.lock().unwrap();
-                        q.push_back(buf[..n].to_vec());
-                        cvar.notify_one();
-                    }
-                    Ok(_) => {}
-                    Err(rusb::Error::Timeout) => {}
-                    Err(rusb::Error::NoDevice) | Err(rusb::Error::Pipe) => break,
-                    Err(_) => {}
-                }
-            }
-        })
-    };
-
-    let transport = LibusbTransport {
-        handle,
-        interface: CLOUD_III_S_HID_INTERFACE,
-        ep_in: CLOUD_III_S_HID_EP_IN,
-        product_string: product_string.clone(),
-        rx,
-        stop,
-        reader: Some(reader),
-    };
-    Ok(Some(DeviceState {
-        transport: HidTransport::Libusb(transport),
-        device_properties: DeviceProperties::new(want_pid, want_vid, product_string),
-    }))
-}
-
 type DeviceFactory = fn(DeviceState) -> Box<dyn Device>;
+
+/// Custom opener for devices that bypass the standard hidapi/hidraw enumeration.
+/// Returns `Ok(Some(state))` if the device was opened, `Ok(None)` if the device
+/// is not present (or the opener gave up gracefully). When set, the registry
+/// loop calls this in priority and `DeviceState::new` skips matching VID/PID
+/// pairs in the hidapi enumeration to avoid a race on the same interface.
+type CustomOpener = fn() -> Result<Option<DeviceState>, DeviceError>;
 
 struct DeviceEntry {
     vendor_ids: &'static [u16],
     product_ids: &'static [u16],
     factory: DeviceFactory,
+    custom_open: Option<CustomOpener>,
 }
+
+#[cfg(target_os = "linux")]
+const CLOUD_III_S_CUSTOM_OPEN: Option<CustomOpener> = Some(cloud_iii_s_wireless::open_via_libusb);
+#[cfg(not(target_os = "linux"))]
+const CLOUD_III_S_CUSTOM_OPEN: Option<CustomOpener> = None;
 
 const DEVICE_REGISTER: &[DeviceEntry] = &[
     DeviceEntry {
         vendor_ids: &cloud_ii_wireless::VENDOR_IDS,
         product_ids: &cloud_ii_wireless::PRODUCT_IDS,
         factory: |s| Box::new(CloudIIWireless::new_from_state(s)),
+        custom_open: None,
     },
     DeviceEntry {
         vendor_ids: &cloud_ii_wireless_dts::VENDOR_IDS,
         product_ids: &cloud_ii_wireless_dts::PRODUCT_IDS,
         factory: |s| Box::new(CloudIIWirelessDTS::new_from_state(s)),
+        custom_open: None,
     },
     DeviceEntry {
         vendor_ids: &cloud_iii_s_wireless::VENDOR_IDS,
         product_ids: &cloud_iii_s_wireless::PRODUCT_IDS,
         factory: |s| Box::new(CloudIIISWireless::new_from_state(s)),
+        custom_open: CLOUD_III_S_CUSTOM_OPEN,
     },
     DeviceEntry {
         vendor_ids: &cloud_iii_wireless::VENDOR_IDS,
         product_ids: &cloud_iii_wireless::PRODUCT_IDS,
         factory: |s| Box::new(CloudIIIWireless::new_from_state(s)),
+        custom_open: None,
     },
     DeviceEntry {
         vendor_ids: &cloud_alpha_wireless::VENDOR_IDS,
         product_ids: &cloud_alpha_wireless::PRODUCT_IDS,
         factory: |s| Box::new(CloudAlphaWireless::new_from_state(s)),
+        custom_open: None,
     },
     DeviceEntry {
         vendor_ids: &cloud_ii_core_wireless::VENDOR_IDS,
         product_ids: &cloud_ii_core_wireless::PRODUCT_IDS,
         factory: |s| Box::new(CloudIICoreWireless::new_from_state(s)),
+        custom_open: None,
     },
 ];
+
+fn is_owned_by_custom_opener(vendor_id: u16, product_id: u16) -> bool {
+    DEVICE_REGISTER
+        .iter()
+        .filter(|e| e.custom_open.is_some())
+        .any(|e| e.vendor_ids.contains(&vendor_id) && e.product_ids.contains(&product_id))
+}
 
 const RESPONSE_BUFFER_SIZE: usize = 256;
 pub const RESPONSE_DELAY: Duration = Duration::from_millis(50);
@@ -395,6 +280,65 @@ fn rusb_to_hid(err: rusb::Error) -> HidError {
 }
 
 impl LibusbTransport {
+    /// Build a `LibusbTransport` from a rusb handle whose target interface has
+    /// already been claimed (and the kernel driver detached if applicable).
+    /// Spawns a background thread that continuously polls `ep_in`, calls
+    /// `packet_hook` for every packet, then queues the packet for callers of
+    /// `read_timeout` / `read_interrupt`.
+    ///
+    /// `packet_hook` lets the caller react to unsolicited reports (e.g. button
+    /// events) that the kernel HID driver no longer surfaces because we
+    /// detached it — that logic is device-specific and lives in the device
+    /// module rather than in this transport.
+    pub fn open(
+        handle: rusb::DeviceHandle<rusb::Context>,
+        interface: u8,
+        ep_in: u8,
+        product_string: Option<String>,
+        mut packet_hook: Box<dyn FnMut(&[u8]) + Send + 'static>,
+    ) -> Self {
+        let handle = std::sync::Arc::new(handle);
+        let rx = std::sync::Arc::new((
+            std::sync::Mutex::new(std::collections::VecDeque::new()),
+            std::sync::Condvar::new(),
+        ));
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let reader = {
+            let handle = std::sync::Arc::clone(&handle);
+            let rx = std::sync::Arc::clone(&rx);
+            let stop = std::sync::Arc::clone(&stop);
+            std::thread::spawn(move || {
+                let mut buf = [0u8; 64];
+                while !stop.load(std::sync::atomic::Ordering::SeqCst) {
+                    match handle.read_interrupt(ep_in, &mut buf, Duration::from_millis(100)) {
+                        Ok(n) if n > 0 => {
+                            packet_hook(&buf[..n]);
+                            let (lock, cvar) = &*rx;
+                            let mut q = lock.lock().unwrap();
+                            q.push_back(buf[..n].to_vec());
+                            cvar.notify_one();
+                        }
+                        Ok(_) => {}
+                        Err(rusb::Error::Timeout) => {}
+                        Err(rusb::Error::NoDevice) | Err(rusb::Error::Pipe) => break,
+                        Err(_) => {}
+                    }
+                }
+            })
+        };
+
+        LibusbTransport {
+            handle,
+            interface,
+            ep_in,
+            product_string,
+            rx,
+            stop,
+            reader: Some(reader),
+        }
+    }
+
     fn set_report(&self, report_type: u16, data: &[u8]) -> Result<usize, HidError> {
         if data.is_empty() {
             return Err(HidError::InvalidZeroSizeData);
@@ -518,18 +462,25 @@ impl Display for DeviceProperties {
 
 impl DeviceState {
     pub fn new(product_ids: &[u16], vendor_ids: &[u16]) -> Result<Vec<Self>, DeviceError> {
-        // Cloud III S Wireless: open via libusb FIRST, before any hidapi/hidraw
-        // enumeration. The kernel hidraw driver, once it has touched the dongle's
-        // HID interface, leaves the INT IN URB queue in a state where responses
-        // never reach a subsequent libusb claim. Doing libusb first (and keeping
-        // it claimed) sidesteps the race.
-        let cloud_iii_s_state = if vendor_ids.contains(&cloud_iii_s_wireless::VENDOR_IDS[0])
-            && product_ids.contains(&cloud_iii_s_wireless::PRODUCT_IDS[0])
-        {
-            open_cloud_iii_s_via_libusb()?
-        } else {
-            None
-        };
+        // Devices with a custom opener (e.g. libusb-based) are opened FIRST,
+        // before any hidapi/hidraw enumeration. Reason: on Linux, once hidraw
+        // has touched some HID interfaces, a subsequent libusb claim races with
+        // the kernel driver and responses can be lost. Custom openers stake
+        // their claim early; the hidapi pass below skips the same VID/PID pairs.
+        let mut custom_states: Vec<DeviceState> = Vec::new();
+        for entry in DEVICE_REGISTER.iter().filter(|e| e.custom_open.is_some()) {
+            let owns_target = entry
+                .vendor_ids
+                .iter()
+                .any(|v| vendor_ids.contains(v))
+                && entry.product_ids.iter().any(|p| product_ids.contains(p));
+            if !owns_target {
+                continue;
+            }
+            if let Some(state) = (entry.custom_open.unwrap())()? {
+                custom_states.push(state);
+            }
+        }
 
         let hid_api = HidApi::new()?;
         let mut potential_devices = HashSet::new();
@@ -545,12 +496,9 @@ impl DeviceState {
         let device_candidates: Vec<(HidDevice, u16, u16)> = hid_api
             .device_list()
             .filter_map(|info| {
-                // Skip Cloud III S: opened via libusb separately below. Letting
-                // hidapi-hidraw open `/dev/hidraw*` here would race with our
-                // detach_kernel_driver/claim_interface call.
-                if info.vendor_id() == cloud_iii_s_wireless::VENDOR_IDS[0]
-                    && info.product_id() == cloud_iii_s_wireless::PRODUCT_IDS[0]
-                {
+                // Skip devices owned by a custom opener; letting hidapi open
+                // `/dev/hidraw*` here would race with the custom claim.
+                if is_owned_by_custom_opener(info.vendor_id(), info.product_id()) {
                     return None;
                 }
                 if product_ids.contains(&info.product_id())
@@ -591,7 +539,7 @@ impl DeviceState {
             })
             .collect();
 
-        if device_candidates.is_empty() && cloud_iii_s_state.is_none() {
+        if device_candidates.is_empty() && custom_states.is_empty() {
             if !potential_devices.is_empty() {
                 let names = potential_devices
                     .iter()
@@ -625,7 +573,9 @@ impl DeviceState {
                 }
             })
             .collect();
-        if let Some(state) = cloud_iii_s_state {
+        // Custom-opened devices come first so the connection probe tries them
+        // before falling back to any hidapi candidate.
+        for state in custom_states.into_iter().rev() {
             states.insert(0, state);
         }
         Ok(states)

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,4 +1,5 @@
 pub mod cloud_alpha_wireless;
+pub mod cloud_flight_wireless;
 pub mod cloud_ii_core_wireless;
 pub mod cloud_ii_wireless;
 pub mod cloud_ii_wireless_dts;
@@ -8,9 +9,10 @@ pub mod cloud_iii_wireless;
 use crate::{
     debug_println,
     devices::{
-        cloud_alpha_wireless::CloudAlphaWireless, cloud_ii_core_wireless::CloudIICoreWireless,
-        cloud_ii_wireless::CloudIIWireless, cloud_ii_wireless_dts::CloudIIWirelessDTS,
-        cloud_iii_s_wireless::CloudIIISWireless, cloud_iii_wireless::CloudIIIWireless,
+        cloud_alpha_wireless::CloudAlphaWireless, cloud_flight_wireless::CloudFlightWireless,
+        cloud_ii_core_wireless::CloudIICoreWireless, cloud_ii_wireless::CloudIIWireless,
+        cloud_ii_wireless_dts::CloudIIWirelessDTS, cloud_iii_s_wireless::CloudIIISWireless,
+        cloud_iii_wireless::CloudIIIWireless,
     },
 };
 use hidapi::{HidApi, HidDevice, HidError};
@@ -61,6 +63,11 @@ const DEVICE_REGISTER: &[DeviceEntry] = &[
         vendor_ids: &cloud_ii_core_wireless::VENDOR_IDS,
         product_ids: &cloud_ii_core_wireless::PRODUCT_IDS,
         factory: |s| Box::new(CloudIICoreWireless::new_from_state(s)),
+    },
+    DeviceEntry {
+        vendor_ids: &cloud_flight_wireless::VENDOR_IDS,
+        product_ids: &cloud_flight_wireless::PRODUCT_IDS,
+        factory: |s| Box::new(CloudFlightWireless::new_from_state(s)),
     },
 ];
 

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -87,34 +87,34 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
     debug_println!("Found device selecting handler");
 
     // On Linux and MacOS we can just take the first
-    // #[cfg(not(target_os = "windows"))]
-    // {
-    //     let state = states
-    //         .into_iter()
-    //         .next()
-    //         .ok_or(DeviceError::NoDeviceFound())?;
-    //     println!(
-    //         "Connecting to {}",
-    //         state
-    //             .device_properties
-    //             .device_name
-    //             .clone()
-    //             .unwrap_or("???".to_string())
-    //     );
-    //     let entry = DEVICE_REGISTER
-    //         .iter()
-    //         .find(|e| {
-    //             e.vendor_ids.contains(&state.device_properties.vendor_id)
-    //                 && e.product_ids.contains(&state.device_properties.product_id)
-    //         })
-    //         .ok_or(DeviceError::NoDeviceFound())?;
-    //
-    //     let mut device = (entry.factory)(state);
-    //     device.init_capabilities();
-    //     Ok(device)
-    // }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let state = states
+            .into_iter()
+            .next()
+            .ok_or(DeviceError::NoDeviceFound())?;
+        println!(
+            "Connecting to {}",
+            state
+                .device_properties
+                .device_name
+                .clone()
+                .unwrap_or("???".to_string())
+        );
+        let entry = DEVICE_REGISTER
+            .iter()
+            .find(|e| {
+                e.vendor_ids.contains(&state.device_properties.vendor_id)
+                    && e.product_ids.contains(&state.device_properties.product_id)
+            })
+            .ok_or(DeviceError::NoDeviceFound())?;
+
+        let mut device = (entry.factory)(state);
+        device.init_capabilities();
+        Ok(device)
+    }
     // On Windows we have to check which interface can be used
-    // #[cfg(target_os = "windows")]
+    #[cfg(target_os = "windows")]
     {
         let mut device = None;
         for state in states {
@@ -140,7 +140,7 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
             let probe_packet = test_device
                 .get_query_packets()
                 .into_iter()
-                .nth(2)
+                .next()
                 .expect("Why is there a device without packets ???");
 
             test_device.prepare_write();
@@ -151,16 +151,6 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
                 debug_println!("Failed to open: {_e:?}");
                 continue;
             } else {
-                std::thread::sleep(RESPONSE_DELAY);
-
-                if let Some(events) = test_device.wait_for_updates(Duration::from_secs(1)) {
-                    for event in events {
-                        debug_println!("got response {event:?}");
-                    }
-                } else {
-                    continue;
-                }
-
                 device = Some(test_device);
                 break;
             }

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -313,11 +313,10 @@ pub struct DeviceState {
 
 /// HID transport abstraction. Most devices use `Hidapi` (the `hidapi-rs` library
 /// which talks to `/dev/hidrawN` on Linux). The `Libusb` variant is for devices
-/// that need direct USB access — specifically the Cloud III S Wireless on
-/// firmware ≥ 0x4118, where the kernel hidraw stack causes RF-forwarded query
-/// responses to be lost. With `Libusb` we detach the kernel driver, claim the
-/// HID interface exclusively, and issue raw SET_REPORT class control transfers
-/// + INT IN reads ourselves.
+/// that need direct USB access - specifically the Cloud III S Wireless where the 
+/// kernel hidraw stack causes RF-forwarded query responses to be lost. 
+/// With `Libusb` we detach the kernel driver, claim the HID interface exclusively, 
+/// and issue raw SET_REPORT class control transfers + INT IN reads ourselves.
 pub enum HidTransport {
     Hidapi(HidDevice),
     Libusb(LibusbTransport),

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -153,8 +153,21 @@ pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
                 })
                 .ok_or(DeviceError::NoDeviceFound())?;
 
+            // Libusb-opened devices: a successful claim already proves we have
+            // THE control interface (libusb claims by VID/PID, no enumeration
+            // ambiguity). Skip the probe-response gate — the Cloud III S
+            // firmware can sit in a state where writes work but query reads
+            // are silently dropped, and we still want the tray/CLI usable
+            // (EQ presets, mute, etc. all use writes).
+            let is_libusb = matches!(state.transport, HidTransport::Libusb(_));
+
             let mut test_device = (entry.factory)(state);
             test_device.init_capabilities();
+
+            if is_libusb {
+                device = Some(test_device);
+                break;
+            }
 
             let probe_packet = test_device
                 .get_query_packets()
@@ -210,6 +223,47 @@ pub struct LibusbTransport {
     rx: std::sync::Arc<(std::sync::Mutex<std::collections::VecDeque<Vec<u8>>>, std::sync::Condvar)>,
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
     reader: Option<std::thread::JoinHandle<()>>,
+}
+
+// Cleanup hook for the currently-active LibusbTransport. The ctrlc handler
+// calls this on SIGINT/SIGTERM/SIGHUP so the kernel HID driver gets re-attached
+// before the process exits — otherwise the device's own input events (e.g.
+// volume keys) stay broken until the dongle is replugged or manually rebound.
+type LibusbCleanup = Box<dyn Fn() + Send + 'static>;
+static LIBUSB_CLEANUP: std::sync::OnceLock<std::sync::Mutex<Option<LibusbCleanup>>> =
+    std::sync::OnceLock::new();
+static LIBUSB_SIGNAL_INSTALLED: std::sync::Once = std::sync::Once::new();
+
+fn libusb_cleanup_slot() -> &'static std::sync::Mutex<Option<LibusbCleanup>> {
+    LIBUSB_CLEANUP.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+fn install_libusb_signal_handler_once() {
+    LIBUSB_SIGNAL_INSTALLED.call_once(|| {
+        let _ = ctrlc::set_handler(|| {
+            if let Ok(mut g) = libusb_cleanup_slot().lock() {
+                if let Some(cleanup) = g.take() {
+                    cleanup();
+                }
+            }
+            std::process::exit(130);
+        });
+    });
+}
+
+fn register_libusb_cleanup(cleanup: LibusbCleanup) {
+    install_libusb_signal_handler_once();
+    if let Ok(mut g) = libusb_cleanup_slot().lock() {
+        *g = Some(cleanup);
+    }
+}
+
+fn clear_libusb_cleanup() {
+    if let Some(slot) = LIBUSB_CLEANUP.get() {
+        if let Ok(mut g) = slot.lock() {
+            *g = None;
+        }
+    }
 }
 
 impl Debug for HidTransport {
@@ -323,6 +377,20 @@ impl LibusbTransport {
             })
         };
 
+        // Register a SIGINT/SIGTERM/SIGHUP cleanup so a Ctrl+C exit re-attaches
+        // the kernel HID driver. Without this, Drop wouldn't run on signal-kill
+        // and the device's own input events (volume keys etc.) would stop
+        // working until the dongle is replugged.
+        {
+            let h = std::sync::Arc::clone(&handle);
+            let s = std::sync::Arc::clone(&stop);
+            register_libusb_cleanup(Box::new(move || {
+                s.store(true, std::sync::atomic::Ordering::SeqCst);
+                let _ = h.release_interface(interface);
+                let _ = h.attach_kernel_driver(interface);
+            }));
+        }
+
         LibusbTransport {
             handle,
             interface,
@@ -409,6 +477,7 @@ impl LibusbTransport {
 
 impl Drop for LibusbTransport {
     fn drop(&mut self) {
+        clear_libusb_cleanup();
         self.stop.store(true, std::sync::atomic::Ordering::SeqCst);
         if let Some(t) = self.reader.take() {
             let _ = t.join();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use std::sync::OnceLock;
 #[cfg(target_os = "linux")]
 use std::{fs, io, process::Command, time::Duration};
 
@@ -7,11 +8,18 @@ use dialog::{Choice, DialogBox};
 // #![warn(missing_docs)]
 pub mod devices;
 
+pub static VERBOSE: OnceLock<bool> = OnceLock::new();
+
 #[macro_export]
 macro_rules! debug_println {
     ($($args:tt)*) => {
         #[cfg(debug_assertions)]
         println!($($args)*);
+
+        #[cfg(not(debug_assertions))]
+        if *$crate::VERBOSE.get().unwrap_or(&false) {
+            println!($($args)*);
+        }
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,11 @@ mod tray_battery_icon_state;
 
 #[cfg(not(target_os = "linux"))]
 fn main() {
+    use clap::ArgAction;
     use std::sync::mpsc;
 
     use hyper_headset::devices::{DeviceEvent, DeviceProperties};
+    use hyper_headset::VERBOSE;
     use winit::event_loop::{ControlFlow, EventLoop, EventLoopProxy};
 
     use crate::status_tray_not_linux::TrayApp;
@@ -34,6 +36,7 @@ fn main() {
 
         let matches = Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
+        .disable_version_flag(false)
         .author(env!("CARGO_PKG_AUTHORS"))
         .about("A tray application for monitoring HyperX headsets.")
         .arg(
@@ -52,7 +55,16 @@ fn main() {
                 .default_value("true")
                 .value_parser(clap::value_parser!(bool)),
         )
+        .arg(Arg::new("verbose")
+            .long("verbose")
+            .short('v')
+            .action(ArgAction::SetTrue)
+            .required(false)
+            .help("Use verbose output ")
+        )
         .get_matches();
+
+        VERBOSE.set(matches.get_flag("verbose")).unwrap();
 
         let press_mute_key = *matches.get_one::<bool>("press_mute_key").unwrap_or(&true);
         let mut enigo = if press_mute_key {
@@ -128,6 +140,7 @@ fn main() {
 
 #[cfg(target_os = "linux")]
 fn main() {
+    use clap::ArgAction;
     use clap::{Arg, Command};
     use enigo::{Direction, Enigo, Key, Keyboard, Settings};
     use std::sync::mpsc;
@@ -136,8 +149,8 @@ fn main() {
     use hyper_headset::devices::connect_compatible_device;
     use status_tray::{StatusTray, TrayHandler};
 
-    use hyper_headset::act_as_askpass_handler;
     use hyper_headset::prompt_user_for_udev_rule;
+    use hyper_headset::{act_as_askpass_handler, VERBOSE};
 
     if let Ok(name) = std::env::current_exe() {
         if let Some(name) = name.to_str() {
@@ -151,6 +164,7 @@ fn main() {
     prompt_user_for_udev_rule();
     let matches = Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
+        .disable_version_flag(false)
         .author(env!("CARGO_PKG_AUTHORS"))
         .about("A tray application for monitoring HyperX headsets.")
         .arg(
@@ -169,6 +183,13 @@ fn main() {
                 .default_value("true")
                 .value_parser(clap::value_parser!(bool)),
         )
+        .arg(Arg::new("verbose")
+            .long("verbose")
+            .short('v')
+            .action(ArgAction::SetTrue)
+            .required(false)
+            .help("Use verbose output ")
+        )
         .get_matches();
 
     let press_mute_key = *matches.get_one::<bool>("press_mute_key").unwrap_or(&true);
@@ -183,6 +204,8 @@ fn main() {
     } else {
         None
     };
+    VERBOSE.set(matches.get_flag("verbose")).unwrap();
+
     let refresh_interval = *matches.get_one::<u64>("refresh_interval").unwrap_or(&3);
     let refresh_interval = Duration::from_secs(refresh_interval);
     let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
## Cloud III S Wireless: libusb transport, generic refactor, mute fix

### Problem

Restores reliable headset state queries (battery, charge, side tone, voice prompt, color, auto-shutdown, mute) on Cloud III S Wireless under Linux, and lifts the libusb-based workaround into a clean transport abstraction so other devices can opt into it without polluting `mod.rs`.

Disclaimer : made with the help of AI (Claude Code)

### Diagnosis

- I believe **Linux hidraw drops RF-forwarded responses on this dongle.** Once `/dev/hidrawN` has been opened, query responses that travel over RF (battery, charge, side tone, …) silently never reach user space. NGenuity uses raw USB on Windows; I replicate that on Linux via libusb, hence completely bypassing hidraw.
- **The previous `write_hid_report` override sent SET_REPORT type Feature**, which the firmware ignores on Report ID 0x0c. NGenuity always uses type Output. The override is removed; the default `hid_device.write()` produces the correct request.
- **Mute was sent via Report ID 0x05 (`05 02` / `05 00`)** which did not seem to work. Replaced with the 0x0c-protocol cmd `0x01` (`0c 02 03 00 00 01 <0|1>`), confirmed by USB capture of NGenuity.

### Changes

- Added dependency to rusb (already a transitive dependency).
- New generic `HidTransport { Hidapi(...), Libusb(...) }` and `LibusbTransport` in `mod.rs`. The libusb variant detaches the kernel HID driver, claims the interface, and drives raw `SET_REPORT` control transfers + INT IN reads through a background reader thread.
- `DeviceEntry` gained a `custom_open: Option<CustomOpener>` hook so devices can register a non-hidapi opener. The hidapi enumeration generically skips VID/PID pairs owned by a custom opener.
- Cloud III S-specific code (USB topology constants, libusb opener, Consumer Control → media key forwarding) lives in `cloud_iii_s_wireless.rs`, gated `#[cfg(target_os = "linux")]`.
- Mic mute now uses the 0x0c-protocol cmd `0x01`. The notification path (`0d 02 03 00 03 <val>`) was already handled.

### Notes

- On Wayland, the Consumer Control button forwarding (vol up/down, play/pause) depends on the compositor accepting libei input emulation; works out of the box on X11.
