### PR TITLE
Add bluetooth fallback to read battery level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ name = "hyper_headset"
 version = "1.8.0"
 dependencies = [
  "clap 4.5.58",
+ "dbus",
  "dialog",
  "enigo",
  "hidapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ thistermination = "1.0.0"
 dialog = "0.3.0"
 ksni = "0.2.0"
 shell-escape = "0.1.5"
+dbus = "0.9"
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 tray-icon = "0.21.3"

--- a/src/bin/hyper_headset_cli.rs
+++ b/src/bin/hyper_headset_cli.rs
@@ -35,7 +35,7 @@ fn create_command(device: &Result<Headset, DeviceError>) -> Command {
                     "Set the delay in minutes after which the headset will automatically shutdown.\n0 will disable automatic shutdown.",
                 )
                     .hide(!SHOW_ALL_OPTIONS
-                        && !device_supports(device, |p| p.can_set_automatic_shutdown))
+                        && !device_supports(device, |d| d.can_set_automatic_shutdown))
                 .value_parser(clap::value_parser!(u8)),
         )
         .arg(
@@ -44,7 +44,7 @@ fn create_command(device: &Result<Headset, DeviceError>) -> Command {
                 .required(false)
                 .help("Mute or unmute the headset.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |p| p.can_set_mute))
+                    && !device_supports(device, |d| d.can_set_mute))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -53,7 +53,7 @@ fn create_command(device: &Result<Headset, DeviceError>) -> Command {
                 .required(false)
                 .help("Enable or disable side tone.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |p| p.can_set_side_tone))
+                    && !device_supports(device, |d| d.can_set_side_tone))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -62,7 +62,7 @@ fn create_command(device: &Result<Headset, DeviceError>) -> Command {
                 .required(false)
                 .help("Set the side tone volume.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |p| p.can_set_side_tone_volume))
+                    && !device_supports(device, |d| d.can_set_side_tone_volume))
                 .value_parser(clap::value_parser!(u8)),
         )
         .arg(
@@ -71,7 +71,7 @@ fn create_command(device: &Result<Headset, DeviceError>) -> Command {
                 .required(false)
                 .help("Enable voice prompt. This may not be supported on your device.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |p| p.can_set_voice_prompt))
+                    && !device_supports(device, |d| d.can_set_voice_prompt))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -80,7 +80,7 @@ fn create_command(device: &Result<Headset, DeviceError>) -> Command {
                 .required(false)
                 .help("Enables surround sound. This may be on by default and cannot be changed on your device.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |p| p.can_set_surround_sound))
+                    && !device_supports(device, |d| d.can_set_surround_sound))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -89,7 +89,7 @@ fn create_command(device: &Result<Headset, DeviceError>) -> Command {
                 .required(false)
                 .help("Mute or unmute playback.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |p| p.can_set_silent_mode))
+                    && !device_supports(device, |d| d.can_set_silent_mode))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -98,7 +98,7 @@ fn create_command(device: &Result<Headset, DeviceError>) -> Command {
                 .required(false)
                 .help("Activates noise gate.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |p| p.can_set_silent_mode))
+                    && !device_supports(device, |d| d.can_set_silent_mode))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(

--- a/src/bin/hyper_headset_cli.rs
+++ b/src/bin/hyper_headset_cli.rs
@@ -2,21 +2,24 @@ use std::{process::exit, time::Duration};
 
 use clap::{Arg, ArgAction, Command};
 use hyper_headset::{
-    devices::{connect_compatible_device, Device, DeviceError, DeviceEvent},
+    devices::{connect_compatible_device, DeviceError, DeviceEvent, DeviceProperties, Headset},
     VERBOSE,
 };
 
 const SHOW_ALL_OPTIONS: bool = false;
 
 /// helper function to enable help messages
-fn device_supports<F>(device: &Result<Box<dyn Device>, DeviceError>, f: F) -> bool
+fn device_supports<F>(device: &Result<Headset, DeviceError>, f: F) -> bool
 where
-    F: FnOnce(&Box<dyn Device>) -> bool,
+    F: FnOnce(&DeviceProperties) -> bool,
 {
-    device.as_ref().map(f).unwrap_or(false)
+    device
+        .as_ref()
+        .map(|headset| f(&headset.device_properties()))
+        .unwrap_or(false)
 }
 
-fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
+fn create_command(device: &Result<Headset, DeviceError>) -> Command {
     Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .disable_version_flag(false)
@@ -32,7 +35,7 @@ fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
                     "Set the delay in minutes after which the headset will automatically shutdown.\n0 will disable automatic shutdown.",
                 )
                     .hide(!SHOW_ALL_OPTIONS
-                        && !device_supports(device, |d| d.can_set_automatic_shutdown()))
+                        && !device_supports(device, |p| p.can_set_automatic_shutdown))
                 .value_parser(clap::value_parser!(u8)),
         )
         .arg(
@@ -41,7 +44,7 @@ fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
                 .required(false)
                 .help("Mute or unmute the headset.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |d| d.can_set_mute()))
+                    && !device_supports(device, |p| p.can_set_mute))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -50,7 +53,7 @@ fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
                 .required(false)
                 .help("Enable or disable side tone.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |d| d.can_set_side_tone()))
+                    && !device_supports(device, |p| p.can_set_side_tone))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -59,7 +62,7 @@ fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
                 .required(false)
                 .help("Set the side tone volume.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |d| d.can_set_side_tone_volume()))
+                    && !device_supports(device, |p| p.can_set_side_tone_volume))
                 .value_parser(clap::value_parser!(u8)),
         )
         .arg(
@@ -68,7 +71,7 @@ fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
                 .required(false)
                 .help("Enable voice prompt. This may not be supported on your device.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |d| d.can_set_voice_prompt()))
+                    && !device_supports(device, |p| p.can_set_voice_prompt))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -77,7 +80,7 @@ fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
                 .required(false)
                 .help("Enables surround sound. This may be on by default and cannot be changed on your device.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |d| d.can_set_surround_sound()))
+                    && !device_supports(device, |p| p.can_set_surround_sound))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -86,7 +89,7 @@ fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
                 .required(false)
                 .help("Mute or unmute playback.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |d| d.can_set_silent_mode()))
+                    && !device_supports(device, |p| p.can_set_silent_mode))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -95,7 +98,7 @@ fn create_command(device: &Result<Box<dyn Device>, DeviceError>) -> Command {
                 .required(false)
                 .help("Activates noise gate.")
                 .hide(!SHOW_ALL_OPTIONS
-                    && !device_supports(device, |d| d.can_set_silent_mode()))
+                    && !device_supports(device, |p| p.can_set_silent_mode))
                 .value_parser(clap::value_parser!(bool)),
         )
         .arg(
@@ -225,7 +228,7 @@ fn main() {
 
     if let Some(output_json) = matches.get_one::<bool>("json") {
         if *output_json {
-            let properties = &device.get_device_state().device_properties;
+            let properties = device.device_properties();
             let mut headset_info_json = "{\n  ".to_string();
 
             let json_properties: Vec<String> = properties
@@ -257,9 +260,9 @@ fn main() {
             headset_info_json += "\n}";
             println!("{}", headset_info_json);
         } else {
-            println!("{}", device.get_device_state().device_properties);
+            println!("{}", device.device_properties());
         }
     } else {
-        println!("{}", device.get_device_state().device_properties);
+        println!("{}", device.device_properties());
     }
 }

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -23,6 +23,7 @@ pub struct BluetoothHeadset {
     path: Path<'static>,
     name: Option<String>,
     battery_level: Option<u8>,
+    connected: bool,
 }
 
 impl BluetoothHeadset {
@@ -61,6 +62,7 @@ impl BluetoothHeadset {
                     path,
                     name,
                     battery_level: None,
+                    connected: true,
                 };
                 headset.battery_level = headset.read_battery().ok().flatten();
                 return Ok(Some(headset));
@@ -88,8 +90,10 @@ impl BluetoothHeadset {
     }
 
     /// Re-locate the headset and refresh the cached battery. The last good
-    /// reading is kept across transient HFP disruptions. An error (including
-    /// the headset no longer being connected) signals the caller to reconnect.
+    /// reading is kept across transient HFP disruptions. When the headset can
+    /// no longer be reached, `connected` is cleared so the next
+    /// `device_properties()` reflects it, and an error signals the caller to
+    /// reconnect.
     pub fn refresh(&mut self) -> Result<(), DeviceError> {
         match BluetoothHeadset::find() {
             Ok(Some(fresh)) => {
@@ -98,7 +102,10 @@ impl BluetoothHeadset {
                 self.battery_level = battery_level;
                 Ok(())
             }
-            _ => Err(DeviceError::NoDeviceFound()),
+            _ => {
+                self.connected = false;
+                Err(DeviceError::NoDeviceFound())
+            }
         }
     }
 
@@ -108,7 +115,7 @@ impl BluetoothHeadset {
     pub fn device_properties(&self) -> DeviceProperties {
         let mut props = DeviceProperties::new(0, 0, self.name.clone());
         props.battery_level = self.battery_level;
-        props.connected = Some(true);
+        props.connected = Some(self.connected);
         props
     }
 }

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use dbus::arg::{PropMap, RefArg};
+use dbus::blocking::stdintf::org_freedesktop_dbus::Properties;
+use dbus::blocking::Connection;
+use dbus::Path;
+use hyper_headset::devices::DeviceProperties;
+
+const HYPERX_NAME_HINT: &str = "HyperX";
+const DBUS_TIMEOUT: Duration = Duration::from_millis(2000);
+
+pub struct BluetoothHeadset {
+    conn: Connection,
+    path: Path<'static>,
+    name: Option<String>,
+}
+
+impl BluetoothHeadset {
+    pub fn find() -> Result<Option<Self>, dbus::Error> {
+        let conn = Connection::new_system()?;
+        let proxy = conn.with_proxy("org.bluez", "/", DBUS_TIMEOUT);
+        let (objects,): (HashMap<Path<'static>, HashMap<String, PropMap>>,) = proxy.method_call(
+            "org.freedesktop.DBus.ObjectManager",
+            "GetManagedObjects",
+            (),
+        )?;
+
+        for (path, ifaces) in objects {
+            let Some(dev) = ifaces.get("org.bluez.Device1") else {
+                continue;
+            };
+            let connected = dev
+                .get("Connected")
+                .and_then(|v| v.0.as_any().downcast_ref::<bool>().copied())
+                .unwrap_or(false);
+            if !connected {
+                continue;
+            }
+            let name = dev
+                .get("Name")
+                .or_else(|| dev.get("Alias"))
+                .and_then(|v| v.0.as_str().map(str::to_string));
+            if name
+                .as_deref()
+                .is_some_and(|n| n.contains(HYPERX_NAME_HINT))
+            {
+                return Ok(Some(Self { conn, path, name }));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Reads `org.bluez.Battery1.Percentage`. Returns `None` if the interface
+    /// is absent, or if the value is reported by the GATT Battery Service which
+    /// the HyperX firmware exposes as a stub always returning `0`. The real
+    /// value comes from the HFP `AT+BIEV` indicator pushed by PipeWire/oFono.
+    pub fn battery(&self) -> Result<Option<u8>, dbus::Error> {
+        let proxy = self.conn.with_proxy("org.bluez", &self.path, DBUS_TIMEOUT);
+        let Ok(percentage) = proxy.get::<u8>("org.bluez.Battery1", "Percentage") else {
+            return Ok(None);
+        };
+        let source = proxy
+            .get::<String>("org.bluez.Battery1", "Source")
+            .unwrap_or_default();
+        if percentage == 0 && source == "GATT Battery Service" {
+            return Ok(None);
+        }
+        Ok(Some(percentage))
+    }
+}
+
+/// Build a `DeviceProperties` snapshot from a Bluetooth-connected headset.
+/// Only battery and name are populated; the rest stays `None` so the tray UI
+/// only shows what we actually know.
+pub fn to_device_properties(bt: &BluetoothHeadset, battery_level: Option<u8>) -> DeviceProperties {
+    let mut props = DeviceProperties::new(0, 0, bt.name.clone());
+    props.battery_level = battery_level;
+    props.connected = Some(true);
+    props
+}

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -5,18 +5,29 @@ use dbus::arg::{PropMap, RefArg};
 use dbus::blocking::stdintf::org_freedesktop_dbus::Properties;
 use dbus::blocking::Connection;
 use dbus::Path;
-use hyper_headset::devices::DeviceProperties;
+
+use crate::devices::{DeviceError, DeviceProperties};
 
 const HYPERX_NAME_HINT: &str = "HyperX";
 const DBUS_TIMEOUT: Duration = Duration::from_millis(2000);
 
+/// A HyperX headset reached over Bluetooth (BlueZ), used as a fallback backend
+/// when no USB HID dongle is present.
+///
+/// Read-only: only the battery level and name are exposed.  The headset's
+/// Airoha RACE config (voice prompt, auto power off, …) is reachable over BLE
+/// GATT but writes don't persist on this firmware, so we deliberately don't
+/// surface settings here.
 pub struct BluetoothHeadset {
     conn: Connection,
     path: Path<'static>,
     name: Option<String>,
+    battery_level: Option<u8>,
 }
 
 impl BluetoothHeadset {
+    /// Locate a connected HyperX headset on the system bus and read its battery.
+    /// Returns `Ok(None)` when no connected HyperX device is present.
     pub fn find() -> Result<Option<Self>, dbus::Error> {
         let conn = Connection::new_system()?;
         let proxy = conn.with_proxy("org.bluez", "/", DBUS_TIMEOUT);
@@ -45,7 +56,14 @@ impl BluetoothHeadset {
                 .as_deref()
                 .is_some_and(|n| n.contains(HYPERX_NAME_HINT))
             {
-                return Ok(Some(Self { conn, path, name }));
+                let mut headset = Self {
+                    conn,
+                    path,
+                    name,
+                    battery_level: None,
+                };
+                headset.battery_level = headset.read_battery().ok().flatten();
+                return Ok(Some(headset));
             }
         }
         Ok(None)
@@ -55,7 +73,7 @@ impl BluetoothHeadset {
     /// is absent, or if the value is reported by the GATT Battery Service which
     /// the HyperX firmware exposes as a stub always returning `0`. The real
     /// value comes from the HFP `AT+BIEV` indicator pushed by PipeWire/oFono.
-    pub fn battery(&self) -> Result<Option<u8>, dbus::Error> {
+    fn read_battery(&self) -> Result<Option<u8>, dbus::Error> {
         let proxy = self.conn.with_proxy("org.bluez", &self.path, DBUS_TIMEOUT);
         let Ok(percentage) = proxy.get::<u8>("org.bluez.Battery1", "Percentage") else {
             return Ok(None);
@@ -68,14 +86,29 @@ impl BluetoothHeadset {
         }
         Ok(Some(percentage))
     }
-}
 
-/// Build a `DeviceProperties` snapshot from a Bluetooth-connected headset.
-/// Only battery and name are populated; the rest stays `None` so the tray UI
-/// only shows what we actually know.
-pub fn to_device_properties(bt: &BluetoothHeadset, battery_level: Option<u8>) -> DeviceProperties {
-    let mut props = DeviceProperties::new(0, 0, bt.name.clone());
-    props.battery_level = battery_level;
-    props.connected = Some(true);
-    props
+    /// Re-locate the headset and refresh the cached battery. The last good
+    /// reading is kept across transient HFP disruptions. An error (including
+    /// the headset no longer being connected) signals the caller to reconnect.
+    pub fn refresh(&mut self) -> Result<(), DeviceError> {
+        match BluetoothHeadset::find() {
+            Ok(Some(fresh)) => {
+                let battery_level = fresh.battery_level.or(self.battery_level);
+                *self = fresh;
+                self.battery_level = battery_level;
+                Ok(())
+            }
+            _ => Err(DeviceError::NoDeviceFound()),
+        }
+    }
+
+    /// Build a `DeviceProperties` snapshot from the Bluetooth headset. Only
+    /// battery, name and connection state are populated; the rest stays `None`
+    /// so the UI only shows what we actually know.
+    pub fn device_properties(&self) -> DeviceProperties {
+        let mut props = DeviceProperties::new(0, 0, self.name.clone());
+        props.battery_level = self.battery_level;
+        props.connected = Some(true);
+        props
+    }
 }

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1000,7 +1000,7 @@ pub trait Device {
             DeviceEvent::AutomaticShutdownAfter(delay) => {
                 if let Some(packet) = self.set_automatic_shut_down_packet(delay) {
                     self.prepare_write();
-                    if let Err(err) = self.get_device_state().hid_device.write(&packet) {
+                    if let Err(err) = self.get_device_state().write_hid_report(&packet) {
                         Err(format!(
                             "Failed to set automatic shutdown with error: {:?}",
                             err
@@ -1013,7 +1013,7 @@ pub trait Device {
             DeviceEvent::Muted(mute) => {
                 if let Some(packet) = self.set_mute_packet(mute) {
                     self.prepare_write();
-                    if let Err(err) = self.get_device_state().hid_device.write(&packet) {
+                    if let Err(err) = self.get_device_state().write_hid_report(&packet) {
                         Err(format!("Failed to mute with error: {:?}", err))?;
                     }
                 } else {
@@ -1023,7 +1023,7 @@ pub trait Device {
             DeviceEvent::SideToneOn(enable) => {
                 if let Some(packet) = self.set_side_tone_packet(enable) {
                     self.prepare_write();
-                    if let Err(err) = self.get_device_state().hid_device.write(&packet) {
+                    if let Err(err) = self.get_device_state().write_hid_report(&packet) {
                         Err(format!("Failed to enable side tone with error: {:?}", err))?;
                     }
                 } else {
@@ -1033,7 +1033,7 @@ pub trait Device {
             DeviceEvent::SideToneVolume(volume) => {
                 if let Some(packet) = self.set_side_tone_volume_packet(volume) {
                     self.prepare_write();
-                    if let Err(err) = self.get_device_state().hid_device.write(&packet) {
+                    if let Err(err) = self.get_device_state().write_hid_report(&packet) {
                         Err(format!(
                             "Failed to set side tone volume with error: {:?}",
                             err
@@ -1049,7 +1049,7 @@ pub trait Device {
             DeviceEvent::VoicePrompt(enable) => {
                 if let Some(packet) = self.set_voice_prompt_packet(enable) {
                     self.prepare_write();
-                    if let Err(err) = self.get_device_state().hid_device.write(&packet) {
+                    if let Err(err) = self.get_device_state().write_hid_report(&packet) {
                         Err(format!(
                             "Failed to enable voice prompt with error: {:?}",
                             err
@@ -1062,7 +1062,7 @@ pub trait Device {
             DeviceEvent::SurroundSound(surround_sound) => {
                 if let Some(packet) = self.set_surround_sound_packet(surround_sound) {
                     self.prepare_write();
-                    if let Err(err) = self.get_device_state().hid_device.write(&packet) {
+                    if let Err(err) = self.get_device_state().write_hid_report(&packet) {
                         Err(format!(
                             "Failed to set surround sound with error: {:?}",
                             err
@@ -1075,7 +1075,7 @@ pub trait Device {
             DeviceEvent::Silent(mute_playback) => {
                 if let Some(packet) = self.set_silent_mode_packet(mute_playback) {
                     self.prepare_write();
-                    if let Err(err) = self.get_device_state().hid_device.write(&packet) {
+                    if let Err(err) = self.get_device_state().write_hid_report(&packet) {
                         Err(format!("Failed to mute playback with error: {:?}", err))?;
                     }
                 } else {
@@ -1085,7 +1085,7 @@ pub trait Device {
             DeviceEvent::NoiseGateActive(activate) => {
                 if let Some(packet) = self.set_noise_gate_packet(activate) {
                     self.prepare_write();
-                    if let Err(err) = self.get_device_state().hid_device.write(&packet) {
+                    if let Err(err) = self.get_device_state().write_hid_report(&packet) {
                         Err(format!(
                             "Failed to activate noise gate with error: {:?}",
                             err

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -82,7 +82,77 @@ const DEVICE_REGISTER: &[DeviceEntry] = &[
 const RESPONSE_BUFFER_SIZE: usize = 256;
 pub const RESPONSE_DELAY: Duration = Duration::from_millis(50);
 
-pub fn connect_compatible_device() -> Result<Box<dyn Device>, DeviceError> {
+/// A connected headset, either over USB HID (the dongle) or, as a fallback on
+/// Linux, over Bluetooth. Frontends (tray, CLI) consume this uniformly via the
+/// small interface below, regardless of the underlying backend.
+pub enum Headset {
+    Hid(Box<dyn Device>),
+    #[cfg(target_os = "linux")]
+    Bluetooth(crate::bluetooth::BluetoothHeadset),
+}
+
+impl Headset {
+    pub fn device_properties(&self) -> DeviceProperties {
+        match self {
+            Headset::Hid(device) => device.get_device_state().device_properties.clone(),
+            #[cfg(target_os = "linux")]
+            Headset::Bluetooth(bt) => bt.device_properties(),
+        }
+    }
+
+    pub fn active_refresh_state(&mut self) -> Result<(), DeviceError> {
+        match self {
+            Headset::Hid(device) => device.active_refresh_state(),
+            #[cfg(target_os = "linux")]
+            Headset::Bluetooth(bt) => bt.refresh(),
+        }
+    }
+
+    pub fn passive_refresh_state(&mut self) -> Result<(), DeviceError> {
+        match self {
+            Headset::Hid(device) => device.passive_refresh_state(),
+            #[cfg(target_os = "linux")]
+            Headset::Bluetooth(bt) => bt.refresh(),
+        }
+    }
+
+    pub fn allow_passive_refresh(&mut self) -> bool {
+        match self {
+            Headset::Hid(device) => device.allow_passive_refresh(),
+            #[cfg(target_os = "linux")]
+            Headset::Bluetooth(_) => false,
+        }
+    }
+
+    pub fn try_apply(&mut self, command: DeviceEvent) -> Result<(), String> {
+        match self {
+            Headset::Hid(device) => device.try_apply(command),
+            #[cfg(target_os = "linux")]
+            Headset::Bluetooth(_) => {
+                Err("This setting cannot be changed over Bluetooth".to_string())
+            }
+        }
+    }
+}
+
+/// Connect to a compatible headset: a USB HID dongle if present, otherwise
+/// (on Linux) fall back to a Bluetooth-connected HyperX headset.
+pub fn connect_compatible_device() -> Result<Headset, DeviceError> {
+    match connect_hid_device() {
+        Ok(device) => Ok(Headset::Hid(device)),
+        Err(error) => {
+            #[cfg(target_os = "linux")]
+            {
+                if let Ok(Some(bt)) = crate::bluetooth::BluetoothHeadset::find() {
+                    return Ok(Headset::Bluetooth(bt));
+                }
+            }
+            Err(error)
+        }
+    }
+}
+
+fn connect_hid_device() -> Result<Box<dyn Device>, DeviceError> {
     let all_product_ids: Vec<u16> = DEVICE_REGISTER
         .iter()
         .flat_map(|e| e.product_ids.iter().copied())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ use dialog::{Choice, DialogBox};
 // #![warn(missing_docs)]
 pub mod devices;
 
+#[cfg(target_os = "linux")]
+pub mod bluetooth;
+
 pub static VERBOSE: OnceLock<bool> = OnceLock::new();
 
 #[macro_export]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 #[cfg(target_os = "linux")]
+mod bluetooth;
+
+#[cfg(target_os = "linux")]
 mod status_tray;
 
 #[cfg(not(target_os = "linux"))]
@@ -222,10 +225,16 @@ fn main() {
         let mut device = loop {
             match connect_compatible_device() {
                 Ok(d) => break d,
-                Err(e) => {
-                    tray_handler.clear_state();
-                    eprintln!("Connecting failed with error: {e}")
-                }
+                Err(e) => match bluetooth::BluetoothHeadset::find() {
+                    Ok(Some(bt)) => {
+                        let level = bt.battery().ok().flatten();
+                        tray_handler.update(&bluetooth::to_device_properties(&bt, level));
+                    }
+                    _ => {
+                        tray_handler.clear_state();
+                        eprintln!("Connecting failed with error: {e}");
+                    }
+                },
             }
             std::thread::sleep(Duration::from_secs(1));
         };
@@ -242,7 +251,7 @@ fn main() {
                 Ok(()) => (),
                 Err(error) => {
                     eprintln!("{error}");
-                    tray_handler.update(device.get_device_state());
+                    tray_handler.update(&device.get_device_state().device_properties);
                     break; // try to reconnect
                 }
             };
@@ -265,7 +274,7 @@ fn main() {
                 let _ = device.active_refresh_state();
             }
 
-            tray_handler.update(device.get_device_state());
+            tray_handler.update(&device.get_device_state().device_properties);
             run_counter += 1;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 #[cfg(target_os = "linux")]
-mod bluetooth;
-
-#[cfg(target_os = "linux")]
 mod status_tray;
 
 #[cfg(not(target_os = "linux"))]
@@ -100,7 +97,7 @@ fn main() {
             // Run loop
             let mut run_counter = 0;
             loop {
-                let mute_state = device.get_device_state().device_properties.muted;
+                let mute_state = device.device_properties().muted;
                 match if run_counter % 30 == 0 {
                     device.active_refresh_state()
                 } else {
@@ -110,12 +107,12 @@ fn main() {
                     Err(error) => {
                         eprintln!("{error}");
                         let _ = proxy
-                            .send_event(Some(device.get_device_state().device_properties.clone()));
+                            .send_event(Some(device.device_properties()));
                         break; // try to reconnect
                     }
                 };
                 if mute_state.is_some()
-                    && mute_state != device.get_device_state().device_properties.muted
+                    && mute_state != device.device_properties().muted
                 {
                     if let Some(enigo) = &mut enigo {
                         if let Err(e) = enigo.key(Key::F20, Direction::Click) {
@@ -133,7 +130,7 @@ fn main() {
                     let _ = device.active_refresh_state();
                 }
 
-                let _ = proxy.send_event(Some(device.get_device_state().device_properties.clone()));
+                let _ = proxy.send_event(Some(device.device_properties()));
                 run_counter += 1;
             }
         }
@@ -225,16 +222,10 @@ fn main() {
         let mut device = loop {
             match connect_compatible_device() {
                 Ok(d) => break d,
-                Err(e) => match bluetooth::BluetoothHeadset::find() {
-                    Ok(Some(bt)) => {
-                        let level = bt.battery().ok().flatten();
-                        tray_handler.update(&bluetooth::to_device_properties(&bt, level));
-                    }
-                    _ => {
-                        tray_handler.clear_state();
-                        eprintln!("Connecting failed with error: {e}");
-                    }
-                },
+                Err(e) => {
+                    tray_handler.clear_state();
+                    eprintln!("Connecting failed with error: {e}");
+                }
             }
             std::thread::sleep(Duration::from_secs(1));
         };
@@ -242,7 +233,7 @@ fn main() {
         // Run loop
         let mut run_counter = 0;
         loop {
-            let mute_state = device.get_device_state().device_properties.muted;
+            let mute_state = device.device_properties().muted;
             match if run_counter % 30 == 0 {
                 device.active_refresh_state()
             } else {
@@ -251,12 +242,12 @@ fn main() {
                 Ok(()) => (),
                 Err(error) => {
                     eprintln!("{error}");
-                    tray_handler.update(&device.get_device_state().device_properties);
+                    tray_handler.update(&device.device_properties());
                     break; // try to reconnect
                 }
             };
             if mute_state.is_some()
-                && mute_state != device.get_device_state().device_properties.muted
+                && mute_state != device.device_properties().muted
             {
                 if let Some(enigo) = &mut enigo {
                     if let Err(e) = enigo.key(Key::MicMute, Direction::Click) {
@@ -274,7 +265,7 @@ fn main() {
                 let _ = device.active_refresh_state();
             }
 
-            tray_handler.update(&device.get_device_state().device_properties);
+            tray_handler.update(&device.device_properties());
             run_counter += 1;
         }
     }

--- a/src/status_tray.rs
+++ b/src/status_tray.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::Sender;
 
 use hyper_headset::devices::{
-    format_int_value, DeviceEvent, DeviceProperties, DeviceState, PropertyType,
+    format_int_value, DeviceEvent, DeviceProperties, PropertyType,
 };
 use ksni::{
     menu::{StandardItem, SubMenu},
@@ -25,9 +25,9 @@ impl TrayHandler {
         TrayHandler { handle }
     }
 
-    pub fn update(&self, device_state: &DeviceState) {
+    pub fn update(&self, properties: &DeviceProperties) {
         self.handle.update(|tray| {
-            tray.device_properties = Some(device_state.device_properties.clone());
+            tray.device_properties = Some(properties.clone());
         })
     }
 


### PR DESCRIPTION
This PR adds a fallback for devices that support bluetooth (e.g. the Cloud III S Wireless), allowing to get the battery state (and bypass dongle issues).